### PR TITLE
Fix API interoperability

### DIFF
--- a/managed/error.go
+++ b/managed/error.go
@@ -3,16 +3,31 @@ package managed
 import (
 	"net/http"
 	"net/http/httputil"
+	"regexp"
 )
 
 func getErrorMessage(response *http.Response, err error) string {
-	errMsg := []byte(err.Error())
-	var dumpErr error
+	errMsg := err.Error()
 	if response != nil {
-		errMsg, dumpErr = httputil.DumpResponse(response, true)
+		request, dumpErr := httputil.DumpRequest(response.Request, true)
 		if dumpErr != nil {
-			errMsg = []byte("Error while dumping response: " + dumpErr.Error())
+			additional := "Error while dumping request: " + dumpErr.Error()
+			errMsg = errMsg + "\n\n\nDump error:" + additional
+		} else {
+			reqString := string(request)
+			// Replace the Authorization Bearer header with obfuscated value
+			re := regexp.MustCompile(`eyJ(.*)`)
+			reqString = re.ReplaceAllString(reqString, `***`)
+			errMsg = errMsg + "\n\nAPI Request:\n" + reqString
+		}
+
+		response, dumpErr := httputil.DumpResponse(response, true)
+		if dumpErr != nil {
+			additional := "Error while dumping response: " + dumpErr.Error()
+			errMsg = errMsg + "\n\n\nDump error:" + additional
+		} else {
+			errMsg = errMsg + "\n\nAPI Response:\n" + string(response)
 		}
 	}
-	return string(errMsg)
+	return errMsg
 }


### PR DESCRIPTION
When some enum's change on the API side, then
the deserialization fails on the client side since the new fields are not known. This results in failures to use the Terraform provider.

We fix this by ignoring the class of issues that
happens during deserialization.