### PR TITLE
Provide external VPC ID in the VPC resource and fix minor bugs

### DIFF
--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -47,6 +47,7 @@ resource "ybm_vpc" "example-vpc" {
 ### Read-Only
 
 - `account_id` (String) The ID of the account this VPC belongs to.
+- `external_vpc_id` (String) The VPC ID for the YB Managed VPC in the cloud provider(AWS/GCP/Azure)
 - `project_id` (String) The ID of the project this VPC belongs to.
 
 <a id="nestedatt--region_cidr_info"></a>

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -47,7 +47,7 @@ resource "ybm_vpc" "example-vpc" {
 ### Read-Only
 
 - `account_id` (String) The ID of the account this VPC belongs to.
-- `external_vpc_id` (String) The VPC ID for the YB Managed VPC in the cloud provider(AWS/GCP/Azure)
+- `external_vpc_id` (String) The ID of the cloud provider(AWS/GCP/AZzure) VPC where YBM resources are created
 - `project_id` (String) The ID of the project this VPC belongs to.
 
 <a id="nestedatt--region_cidr_info"></a>

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -283,13 +283,13 @@ func (r dataClusterName) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 		return
 	}
 
-	list := res.GetData()
-	if len(list) == 0 {
+	clusterList := res.GetData()
+	if len(clusterList) == 0 {
 		resp.Diagnostics.AddError("Unable to extract the following cluster information: ", fmt.Sprintf("The cluster %v doesn't exist", clusterName))
 		return
 	}
-	Info := list[0].GetInfo()
-	clusterId := Info.GetId()
+	clusterInfo := clusterList[0].GetInfo()
+	clusterId := clusterInfo.GetId()
 
 	scheduleResp, r2, err1 := apiClient.BackupApi.ListBackupSchedules(ctx, accountId, projectId).EntityId(clusterId).Execute()
 	if err1 != nil {
@@ -298,12 +298,12 @@ func (r dataClusterName) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 	}
 
 	var cluster Cluster
-	list1 := scheduleResp.GetData()
-	if len(list1) == 0 {
+	backupScheduleList := scheduleResp.GetData()
+	if len(backupScheduleList) == 0 {
 		resp.Diagnostics.AddError("The default backup schedule was not found for the cluster ", clusterName)
 		return
 	}
-	scheduleId := list1[0].GetInfo().Id
+	scheduleId := backupScheduleList[0].GetInfo().Id
 	var backUpSchedule []BackupScheduleInfo
 
 	backUpInfo := BackupScheduleInfo{

--- a/managed/models.go
+++ b/managed/models.go
@@ -94,6 +94,7 @@ type VPC struct {
 	Name           types.String    `tfsdk:"name"`
 	Cloud          types.String    `tfsdk:"cloud"`
 	GlobalCIDR     types.String    `tfsdk:"global_cidr"`
+	ExternalVPCID  types.String    `tfsdk:"external_vpc_id"`
 	RegionCIDRInfo []VPCRegionInfo `tfsdk:"region_cidr_info"`
 }
 

--- a/managed/resource_read_replica.go
+++ b/managed/resource_read_replica.go
@@ -236,7 +236,7 @@ func (r resourceReadReplicas) Create(ctx context.Context, req tfsdk.CreateResour
 
 	// read status, wait for status to be done
 	retryPolicy := retry.NewConstant(10 * time.Second)
-	retryPolicy = retry.WithMaxDuration(1200*time.Second, retryPolicy)
+	retryPolicy = retry.WithMaxDuration(3600*time.Second, retryPolicy)
 	err = retry.Do(ctx, retryPolicy, func(ctx context.Context) error {
 		primaryClusterState, readInfoOK, message := getClusterState(ctx, accountId, projectId, clusterId, apiClient)
 		if readInfoOK {
@@ -393,7 +393,7 @@ func (r resourceReadReplicas) Update(ctx context.Context, req tfsdk.UpdateResour
 
 	// read status, wait for status to be done
 	retryPolicy := retry.NewConstant(10 * time.Second)
-	retryPolicy = retry.WithMaxDuration(1200*time.Second, retryPolicy)
+	retryPolicy = retry.WithMaxDuration(3600*time.Second, retryPolicy)
 	err = retry.Do(ctx, retryPolicy, func(ctx context.Context) error {
 		primaryClusterState, readInfoOK, message := getClusterState(ctx, accountId, projectId, clusterId, apiClient)
 		if readInfoOK {
@@ -451,7 +451,7 @@ func (r resourceReadReplicas) Delete(ctx context.Context, req tfsdk.DeleteResour
 
 	// read status, wait for status to be done
 	retryPolicy := retry.NewConstant(10 * time.Second)
-	retryPolicy = retry.WithMaxDuration(1200*time.Second, retryPolicy)
+	retryPolicy = retry.WithMaxDuration(3600*time.Second, retryPolicy)
 	err = retry.Do(ctx, retryPolicy, func(ctx context.Context) error {
 		primaryClusterState, readInfoOK, message := getClusterState(ctx, accountId, projectId, clusterId, apiClient)
 		if readInfoOK {

--- a/managed/resource_vpc.go
+++ b/managed/resource_vpc.go
@@ -41,7 +41,7 @@ func (r resourceVPCType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagno
 				Optional:    true,
 			},
 			"external_vpc_id": {
-				Description: "The VPC ID for the YB Managed VPC in the cloud provider(AWS/GCP/Azure)",
+				Description: "The ID of the cloud provider(AWS/GCP/AZzure) VPC where YBM resources are created",
 				Type:        types.StringType,
 				Computed:    true,
 			},

--- a/managed/resource_vpc.go
+++ b/managed/resource_vpc.go
@@ -40,6 +40,11 @@ func (r resourceVPCType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagno
 				Computed:    true,
 				Optional:    true,
 			},
+			"external_vpc_id": {
+				Description: "The VPC ID for the YB Managed VPC in the cloud provider(AWS/GCP/Azure)",
+				Type:        types.StringType,
+				Computed:    true,
+			},
 			"name": {
 				Description: "The description of the VPC.",
 				Type:        types.StringType,
@@ -264,6 +269,7 @@ func resourceVPCRead(accountId string, projectId string, vpcId string, regionMap
 
 	vpc.Name.Value = vpcResp.Data.Spec.GetName()
 	vpc.Cloud.Value = string(vpcResp.Data.Spec.GetCloud())
+	vpc.ExternalVPCID.Value = vpcResp.Data.Info.GetExternalVpcId()
 	if vpcResp.Data.Spec.GetParentCidr() != "" {
 		vpc.GlobalCIDR.Value = vpcResp.Data.Spec.GetParentCidr()
 	} else {

--- a/managed/resource_vpc_peering.go
+++ b/managed/resource_vpc_peering.go
@@ -188,7 +188,7 @@ func (r resourceVPCPeering) Create(ctx context.Context, req tfsdk.CreateResource
 			resp.Diagnostics.AddError("No CIDR specified", "You must specify the CIDR of the application VPC for AWS.")
 			return
 		}
-		if plan.ApplicationVPCInfo.CIDR.IsNull() {
+		if plan.ApplicationVPCInfo.CIDR.IsNull() || plan.ApplicationVPCInfo.CIDR.Value == "" {
 			resp.Diagnostics.AddError("No Application VPC CIDR specified", "The application VPC CIDR must be provided for AWS cloud.")
 			return
 		}

--- a/managed/resource_vpc_peering.go
+++ b/managed/resource_vpc_peering.go
@@ -247,13 +247,6 @@ func (r resourceVPCPeering) Create(ctx context.Context, req tfsdk.CreateResource
 		return
 	}
 
-	if plan.ApplicationVPCInfo.Region.Null {
-		vpcPeering.ApplicationVPCInfo.Region.Null = true
-	}
-	if plan.ApplicationVPCInfo.CIDR.Null {
-		vpcPeering.ApplicationVPCInfo.CIDR.Null = true
-	}
-
 	diags = resp.State.Set(ctx, &vpcPeering)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
This PR provides the external VPC ID( the VPC ID in the cloud provider ) in the VPC resource. This is needed to fully automate VPC peering. 

In addition to it, the following minor bugs have been fixed:
- Check for wrong cluster name in the cluster data source
- Increase timeout during read replica creation to support the creation of a large number of read replicas at once
- TF plan always shows VPC peering resource needs to be updated inspite of no changes to the resources. This has been fixed.