### PR TITLE
Add BYOK feature support to Terraform

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -246,6 +246,7 @@ resource "ybm_cluster" "multi_region_cluster" {
 - `cluster_allow_list_ids` (List of String) List of IDs of the allow lists assigned to the cluster.
 - `cluster_endpoints` (Map of String) The endpoints used to connect to the cluster by region.
 - `cluster_id` (String) The ID of the cluster. Created automatically when a cluster is created. Used to get a specific cluster.
+- `cmk_spec` (Attributes) KMS Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec))
 - `database_track` (String) The track of the database. Stable or Preview.
 - `desired_state` (String) The desired state of the database, Active or Paused. This parameter can be used to pause/resume a cluster.
 - `fault_tolerance` (String) The fault tolerance of the cluster. NONE, NODE, ZONE or REGION.
@@ -309,6 +310,60 @@ Optional:
 - `schedule_id` (String) The ID of the backup schedule. Created automatically when the backup schedule is created. Used to get a specific backup schedule.
 - `state` (String) The state of the backup schedule. Used to pause or resume the backup schedule. Valid values are ACTIVE or PAUSED.
 - `time_interval_in_days` (Number) The time interval in days for the backup schedule.
+
+
+<a id="nestedatt--cmk_spec"></a>
+### Nested Schema for `cmk_spec`
+
+Required:
+
+- `is_enabled` (Boolean) Is Enabled
+- `provider_type` (String) CMK Provider Type.
+
+Optional:
+
+- `aws_cmk_spec` (Attributes) AWS CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--aws_cmk_spec))
+- `gcp_cmk_spec` (Attributes) GCP CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--gcp_cmk_spec))
+
+<a id="nestedatt--cmk_spec--aws_cmk_spec"></a>
+### Nested Schema for `cmk_spec.aws_cmk_spec`
+
+Required:
+
+- `access_key` (String) Access Key
+- `arn_list` (List of String) AWS ARN List
+- `secret_key` (String) Secret Key
+
+
+<a id="nestedatt--cmk_spec--gcp_cmk_spec"></a>
+### Nested Schema for `cmk_spec.gcp_cmk_spec`
+
+Required:
+
+- `gcp_service_account` (Attributes) GCP Service Account (see [below for nested schema](#nestedatt--cmk_spec--gcp_cmk_spec--gcp_service_account))
+- `key_name` (String) Key Name
+- `key_ring_name` (String) Key Ring Name
+- `location` (String) Location
+- `protection_level` (String) Key Protection Level
+
+<a id="nestedatt--cmk_spec--gcp_cmk_spec--gcp_service_account"></a>
+### Nested Schema for `cmk_spec.gcp_cmk_spec.gcp_service_account`
+
+Required:
+
+- `auth_provider_x509_cert_url` (String) Auth Provider X509 Cert URL
+- `auth_uri` (String) Auth URI
+- `client_email` (String) Client Email
+- `client_id` (String) Client ID
+- `client_x509_cert_url` (String) Client X509 Cert URL
+- `private_key` (String) Private Key
+- `private_key_id` (String) Private Key ID
+- `project_id` (String) GCP Project ID
+- `token_uri` (String) Token URI
+- `type` (String) Service Account Type
+- `universe_domain` (String) Google Universe Domain
+
+
 
 
 <a id="nestedatt--cluster_info"></a>

--- a/examples/resources/ybm_cluster/single-region-aws-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-aws-cmk.tf
@@ -1,0 +1,54 @@
+# EAR enabled single region cluster
+# The same cmk_spec can be used for multi region/read replica clusters as well
+
+variable "ysql_password" {
+  type        = string
+  description = "YSQL Password."
+  sensitive   = true
+}
+
+variable "ycql_password" {
+  type        = string
+  description = "YCQL Password."
+  sensitive   = true
+}
+
+resource "ybm_cluster" "single_region" {
+  cluster_name = "test-cluster-with-aws-cmk"
+  # The cloud provider for the cluster is indepedent of the CMK Provider
+  # eg. GCP cluster with AWS CMK is supported
+  cloud_type   = "GCP"
+  cluster_type = "SYNCHRONOUS"
+  cluster_region_info = [
+    {
+      region    = "us-west1"
+      num_nodes = 6
+    }
+  ]
+  cluster_tier           = "PAID"
+  # fault tolerance cannot be NONE for CMK enabled cluster
+  fault_tolerance        = "ZONE"
+
+  cmk_spec = {
+    provider_type = "AWS"
+    aws_cmk_spec = {
+      access_key = "AKIAIOSFODNN7EXAMPLE"
+      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      arn_list = [
+        "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+      ]
+    }
+    is_enabled =  true
+  }
+
+  node_config = {
+    num_cores    = 4
+    disk_size_gb = 50
+  }
+  credentials = {
+    ysql_username = "example_ysql_user"
+    ysql_password = var.ysql_password
+    ycql_username = "example_ycql_user"
+    ycql_password = var.ycql_password
+  }
+}

--- a/examples/resources/ybm_cluster/single-region-gcp-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-gcp-cmk.tf
@@ -1,0 +1,63 @@
+# EAR enabled single region cluster
+# The same cmk_spec can be used for multi region/read replica clusters as well
+
+variable "ysql_password" {
+  type        = string
+  description = "YSQL Password."
+  sensitive   = true
+}
+
+variable "ycql_password" {
+  type        = string
+  description = "YCQL Password."
+  sensitive   = true
+}
+
+resource "ybm_cluster" "single_region" {
+  cluster_name = "test-cluster-with-gcp-cmk"
+  # The cloud provider for the cluster is indepedent of the CMK Provider
+  cloud_type   = "GCP"
+  cluster_type = "SYNCHRONOUS"
+  cluster_region_info = [
+    {
+      region    = "us-west1"
+      num_nodes = 6
+    }
+  ]
+  cluster_tier           = "PAID"
+  # fault tolerance cannot be NONE for CMK enabled cluster
+  fault_tolerance        = "ZONE"
+
+  cmk_spec = {
+    provider_type = "GCP"
+    gcp_cmk_spec = {
+    location = "global"
+    key_ring_name = "example_cmk_key_ring"
+    key_name = "example_cmk_key"
+    protection_level = "software"
+    gcp_service_account = {
+        type = "service_account"
+        project_id = "your-project-id"
+        private_key_id = "your-private-key-id"
+        private_key = "-----BEGIN PRIVATE KEY-----\nYourPrivateRSAKey\n-----END PRIVATE KEY-----\n"
+        client_email = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
+        client_id = "your-client-id"
+        auth_uri = "https://accounts.google.com/o/oauth2/auth"
+        token_uri = "https://accounts.google.com/o/oauth2/token"
+        auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+        client_x509_cert_url = "https://www.googleapis.com/.../your-service-account-email%40your-project-id.iam.gserviceaccount.com"
+        universe_domain = "googleapis.com"
+    }}
+    is_enabled =  true
+  }
+  node_config = {
+    num_cores    = 4
+    disk_size_gb = 50
+  }
+  credentials = {
+    ysql_username = "example_ysql_user"
+    ysql_password = var.ysql_password
+    ycql_username = "example_ycql_user"
+    ycql_password = var.ycql_password
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,10 @@ github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39 h1:ckc1DYAEq9zNMWCMV32T0mqdposIa03zhhkYHPeDfgw=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230612170114-34eb470a0c39/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230418071958-56cbcbea1ba8 h1:+EbHGdfvMtacctw4axs37wth0mXfU5lQ7xQxjZwQhCM=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230418071958-56cbcbea1ba8/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09 h1:B5fnbQTEbM0QX8R77NYCiGVlEzOq66V+lN2OYb+THTI=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230616084337-3e2516a65d09/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/models.go
+++ b/managed/models.go
@@ -29,6 +29,41 @@ type Cluster struct {
 	BackupSchedules     []BackupScheduleInfo `tfsdk:"backup_schedules"`
 	ClusterEndpoints    types.Map            `tfsdk:"cluster_endpoints"`
 	ClusterCertificate  types.String         `tfsdk:"cluster_certificate"`
+	CMKSpec             *CMKSpec             `tfsdk:"cmk_spec"`
+}
+
+type CMKSpec struct {
+	ProviderType types.String `tfsdk:"provider_type"`
+	AWSCMKSpec   *AWSCMKSpec  `tfsdk:"aws_cmk_spec"`
+	GCPCMKSpec   *GCPCMKSpec  `tfsdk:"gcp_cmk_spec"`
+	IsEnabled    types.Bool   `tfsdk:"is_enabled"`
+}
+
+type AWSCMKSpec struct {
+	AccessKey types.String   `tfsdk:"access_key"`
+	SecretKey types.String   `tfsdk:"secret_key"`
+	ARNList   []types.String `tfsdk:"arn_list"`
+}
+
+type GCPCMKSpec struct {
+	KeyRingName       types.String      `tfsdk:"key_ring_name"`
+	KeyName           types.String      `tfsdk:"key_name"`
+	Location          types.String      `tfsdk:"location"`
+	ProtectionLevel   types.String      `tfsdk:"protection_level"`
+	GcpServiceAccount GCPServiceAccount `tfsdk:"gcp_service_account"`
+}
+type GCPServiceAccount struct {
+	Type                    types.String `tfsdk:"type"`
+	ProjectId               types.String `tfsdk:"project_id"`
+	PrivateKey              types.String `tfsdk:"private_key"`
+	PrivateKeyId            types.String `tfsdk:"private_key_id"`
+	ClientEmail             types.String `tfsdk:"client_email"`
+	ClientId                types.String `tfsdk:"client_id"`
+	AuthUri                 types.String `tfsdk:"auth_uri"`
+	TokenUri                types.String `tfsdk:"token_uri"`
+	AuthProviderX509CertUrl types.String `tfsdk:"auth_provider_x509_cert_url"`
+	ClientX509CertUrl       types.String `tfsdk:"client_x509_cert_url"`
+	UniverseDomain          types.String `tfsdk:"universe_domain"`
 }
 
 type BackupScheduleInfo struct {

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -132,6 +132,131 @@ and modify the backup schedule of the cluster being created.`,
 					},
 				}),
 			},
+			"cmk_spec": {
+				Description: "KMS Provider Configuration.",
+				Optional:    true,
+				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+					"provider_type": {
+						Description: "CMK Provider Type.",
+						Type:        types.StringType,
+						Required:    true,
+						Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("AWS", "GCP")},
+					},
+					"is_enabled": {
+						Description: "Is Enabled",
+						Type:        types.BoolType,
+						Required:    true,
+					},
+					"aws_cmk_spec": {
+						Description: "AWS CMK Provider Configuration.",
+						Optional:    true,
+						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+							"access_key": {
+								Description: "Access Key",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"secret_key": {
+								Description: "Secret Key",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"arn_list": {
+								Description: "AWS ARN List",
+								Type:        types.ListType{ElemType: types.StringType},
+								Required:    true,
+							},
+						}),
+					},
+					"gcp_cmk_spec": {
+						Description: "GCP CMK Provider Configuration.",
+						Optional:    true,
+						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+							"key_ring_name": {
+								Description: "Key Ring Name",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"key_name": {
+								Description: "Key Name",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"location": {
+								Description: "Location",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"protection_level": {
+								Description: "Key Protection Level",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"gcp_service_account": {
+								Description: "GCP Service Account",
+								Required:    true,
+								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+									"type": {
+										Description: "Service Account Type",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"project_id": {
+										Description: "GCP Project ID",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"private_key": {
+										Description: "Private Key",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"private_key_id": {
+										Description: "Private Key ID",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"client_email": {
+										Description: "Client Email",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"client_id": {
+										Description: "Client ID",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"auth_uri": {
+										Description: "Auth URI",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"token_uri": {
+										Description: "Token URI",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"auth_provider_x509_cert_url": {
+										Description: "Auth Provider X509 Cert URL",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"client_x509_cert_url": {
+										Description: "Client X509 Cert URL",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"universe_domain": {
+										Description: "Google Universe Domain",
+										Type:        types.StringType,
+										Required:    true,
+									},
+								}),
+							},
+						}),
+					},
+				}),
+			},
 			"cluster_tier": {
 				Description: "FREE (Sandbox) or PAID (Dedicated).",
 				Type:        types.StringType,
@@ -447,6 +572,7 @@ func getPlan(ctx context.Context, plan tfsdk.Plan, cluster *Cluster) diag.Diagno
 	diags.Append(plan.GetAttribute(ctx, path.Root("node_config"), &cluster.NodeConfig)...)
 	diags.Append(plan.GetAttribute(ctx, path.Root("credentials"), &cluster.Credentials)...)
 	diags.Append(plan.GetAttribute(ctx, path.Root("backup_schedules"), &cluster.BackupSchedules)...)
+	diags.Append(plan.GetAttribute(ctx, path.Root("cmk_spec"), &cluster.CMKSpec)...)
 
 	return diags
 }
@@ -460,7 +586,6 @@ func getIDsFromState(ctx context.Context, state tfsdk.State, cluster *Cluster) {
 	state.GetAttribute(ctx, path.Root("cluster_allow_list_ids"), &cluster.ClusterAllowListIDs)
 	state.GetAttribute(ctx, path.Root("cluster_region_info"), &cluster.ClusterRegionInfo)
 	state.GetAttribute(ctx, path.Root("backup_schedules"), &cluster.BackupSchedules)
-
 }
 
 func validateCredentials(credentials Credentials) bool {
@@ -481,6 +606,69 @@ func validateCredentials(credentials Credentials) bool {
 
 }
 
+func createCmkSpec(plan Cluster) (cmkSpec *openapiclient.CMKSpec, cmkSpecOK bool, errorMessage string) {
+	cmkSpecOK = true
+	cmkProvider := plan.CMKSpec.ProviderType.Value
+	cmkSpec = openapiclient.NewCMKSpec(openapiclient.CMKProviderEnum(cmkProvider))
+
+	switch cmkProvider {
+	case "GCP":
+		if plan.CMKSpec.GCPCMKSpec == nil {
+			errorMessage = "Provider type is GCP but GCP CMK spec is missing."
+			cmkSpecOK = false
+			return nil, false, errorMessage
+		}
+		gcpKeyRingName := plan.CMKSpec.GCPCMKSpec.KeyRingName.Value
+		gcpKeyName := plan.CMKSpec.GCPCMKSpec.KeyName.Value
+		gcpLocation := plan.CMKSpec.GCPCMKSpec.Location.Value
+		gcpProtectionLevel := plan.CMKSpec.GCPCMKSpec.ProtectionLevel.Value
+		gcpServiceAccount := plan.CMKSpec.GCPCMKSpec.GcpServiceAccount
+		gcpServiceAccountSpec := openapiclient.NewGCPServiceAccount(
+			gcpServiceAccount.Type.Value,
+			gcpServiceAccount.ProjectId.Value,
+			gcpServiceAccount.PrivateKeyId.Value,
+			gcpServiceAccount.ClientEmail.Value,
+			gcpServiceAccount.ClientId.Value,
+			gcpServiceAccount.AuthUri.Value,
+			gcpServiceAccount.TokenUri.Value,
+			gcpServiceAccount.AuthProviderX509CertUrl.Value,
+			gcpServiceAccount.ClientX509CertUrl.Value,
+		)
+
+		// Appending the optional fields
+		if (!gcpServiceAccount.PrivateKey.Unknown && !gcpServiceAccount.PrivateKey.Null) || gcpServiceAccount.PrivateKey.Value != "" {
+			gcpServiceAccountSpec.SetPrivateKey(gcpServiceAccount.PrivateKey.Value)
+		}
+		if (!gcpServiceAccount.UniverseDomain.Unknown && !gcpServiceAccount.UniverseDomain.Null) || gcpServiceAccount.UniverseDomain.Value != "" {
+			gcpServiceAccountSpec.SetUniverseDomain(gcpServiceAccount.UniverseDomain.Value)
+		}
+
+		gcpCmkSpec := openapiclient.NewGCPCMKSpec(gcpKeyRingName, gcpKeyName, gcpLocation, gcpProtectionLevel)
+		gcpCmkSpec.SetGcpServiceAccount(*gcpServiceAccountSpec)
+		cmkSpec.SetGcpCmkSpec(*gcpCmkSpec)
+	case "AWS":
+		if plan.CMKSpec.AWSCMKSpec == nil {
+			errorMessage = "Provider type is AWS but AWS CMK spec is missing."
+			cmkSpecOK = false
+			return nil, false, errorMessage
+		}
+		awsSecretKey := plan.CMKSpec.AWSCMKSpec.SecretKey.Value
+		awsAccessKey := plan.CMKSpec.AWSCMKSpec.AccessKey.Value
+		awsArnList := make([]string, len(plan.CMKSpec.AWSCMKSpec.ARNList))
+
+		for i, arn := range plan.CMKSpec.AWSCMKSpec.ARNList {
+			awsArnList[i] = arn.Value
+		}
+
+		awsCmkSpec := openapiclient.NewAWSCMKSpec(awsAccessKey, awsSecretKey, awsArnList)
+		cmkSpec.SetAwsCmkSpec(*awsCmkSpec)
+	}
+
+	cmkSpec.SetIsEnabled(plan.CMKSpec.IsEnabled.Value)
+
+	return cmkSpec, cmkSpecOK, errorMessage
+}
+
 // Create a new resource
 func (r resourceCluster) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
 	if !r.p.configured {
@@ -490,9 +678,8 @@ func (r resourceCluster) Create(ctx context.Context, req tfsdk.CreateResourceReq
 		)
 		return
 	}
-
-	var plan Cluster
 	var accountId, message string
+	var plan Cluster
 	var getAccountOK bool
 	resp.Diagnostics.Append(getPlan(ctx, req.Plan, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -559,6 +746,26 @@ func (r resourceCluster) Create(ctx context.Context, req tfsdk.CreateResourceReq
 	}
 
 	createClusterRequest := *openapiclient.NewCreateClusterRequest(*clusterSpec, *credentials)
+
+	var cmkSpec *openapiclient.CMKSpec
+
+	if plan.CMKSpec != nil {
+		var cmkSpecOK bool
+		var errorMessage string
+		// EAR disabled is not supported with cluster creation
+		if !plan.CMKSpec.IsEnabled.Value {
+			resp.Diagnostics.AddError(
+				"EAR will be enabled by default.", "Cluster creation with EAR disabled is not supported.",
+			)
+		}
+		cmkSpec, cmkSpecOK, errorMessage = createCmkSpec(plan)
+
+		if cmkSpecOK {
+			createClusterRequest.SecurityCmkSpec = *openapiclient.NewNullableCMKSpec(cmkSpec)
+		} else {
+			resp.Diagnostics.AddError("Error creating CMK Spec.", errorMessage)
+		}
+	}
 
 	clusterResp, response, err := apiClient.ClusterApi.CreateCluster(ctx, accountId, projectId).CreateClusterRequest(createClusterRequest).Execute()
 	if err != nil {
@@ -689,6 +896,19 @@ func (r resourceCluster) Create(ctx context.Context, req tfsdk.CreateResourceReq
 	}
 
 	cluster, readOK, message := resourceClusterRead(ctx, accountId, projectId, clusterId, backUpSchedules, regions, allowListProvided, allowListIDs, false, apiClient)
+
+	// Update the State file with the unmasked creds for AWS (secret key,access) and GCP (client id,private key)
+	if plan.CMKSpec != nil {
+		providerType := cluster.CMKSpec.ProviderType.Value
+		switch providerType {
+		case "AWS":
+			cluster.CMKSpec.AWSCMKSpec.SecretKey = types.String{Value: string(cmkSpec.GetAwsCmkSpec().SecretKey)}
+			cluster.CMKSpec.AWSCMKSpec.AccessKey = types.String{Value: string(cmkSpec.GetAwsCmkSpec().AccessKey)}
+		case "GCP":
+			cluster.CMKSpec.GCPCMKSpec.GcpServiceAccount.ClientId = types.String{Value: string(cmkSpec.GetGcpCmkSpec().GcpServiceAccount.ClientId)}
+			cluster.CMKSpec.GCPCMKSpec.GcpServiceAccount.PrivateKey = types.String{Value: string(*cmkSpec.GetGcpCmkSpec().GcpServiceAccount.PrivateKey)}
+		}
+	}
 
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the cluster ", message)
@@ -844,7 +1064,25 @@ func (r resourceCluster) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 	if state.BackupSchedules != nil && len(state.BackupSchedules) > 0 {
 		backUpSchedules = append(backUpSchedules, state.BackupSchedules[0])
 	}
+
 	cluster, readOK, message := resourceClusterRead(ctx, state.AccountID.Value, state.ProjectID.Value, state.ClusterID.Value, backUpSchedules, regions, allowListProvided, allowListIDs, false, r.p.client)
+
+	// Fetch the cmkSpec information from State (to get unmasked creds)
+	var cmkSpec CMKSpec
+	req.State.GetAttribute(ctx, path.Root("cmk_spec"), &cmkSpec)
+
+	if cluster.CMKSpec != nil {
+		// Unmask the creds to store in the State file
+		providerType := cluster.CMKSpec.ProviderType.Value
+		switch providerType {
+		case "AWS":
+			cluster.CMKSpec.AWSCMKSpec.SecretKey.Value = cmkSpec.AWSCMKSpec.SecretKey.Value
+			cluster.CMKSpec.AWSCMKSpec.AccessKey.Value = cmkSpec.AWSCMKSpec.AccessKey.Value
+		case "GCP":
+			cluster.CMKSpec.GCPCMKSpec.GcpServiceAccount.ClientId.Value = cmkSpec.GCPCMKSpec.GcpServiceAccount.ClientId.Value
+			cluster.CMKSpec.GCPCMKSpec.GcpServiceAccount.PrivateKey.Value = cmkSpec.GCPCMKSpec.GcpServiceAccount.PrivateKey.Value
+		}
+	}
 
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the cluster", message)
@@ -913,6 +1151,63 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 			}
 			backupScheduleInfo[0] = backupScheduleStruct
 			cluster.BackupSchedules = backupScheduleInfo
+		}
+	}
+
+	cmkResp, _, err := apiClient.ClusterApi.GetClusterCMK(context.Background(), accountId, projectId, clusterId).Execute()
+	if cmkResp.Data.Get() != nil {
+		cmkSpec := CMKSpec{}
+		cmkData := cmkResp.GetData()
+
+		cmkSpec.ProviderType = types.String{Value: string(cmkData.GetProviderType())}
+		cmkSpec.IsEnabled = types.Bool{Value: bool(cmkData.GetIsEnabled())}
+
+		switch cmkSpec.ProviderType.Value {
+		case "AWS":
+			awsCMKSpec := AWSCMKSpec{
+				AccessKey: types.String{Value: cmkData.GetAwsCmkSpec().AccessKey},
+				SecretKey: types.String{Value: cmkData.GetAwsCmkSpec().SecretKey},
+				ARNList:   []types.String{},
+			}
+			cmkSpec.AWSCMKSpec = &awsCMKSpec
+
+			for _, arn := range cmkData.GetAwsCmkSpec().ArnList {
+				cmkSpec.AWSCMKSpec.ARNList = append(cmkSpec.AWSCMKSpec.ARNList, types.String{Value: arn})
+			}
+			cluster.CMKSpec = &cmkSpec
+
+		case "GCP":
+			gcpCMKSpec := GCPCMKSpec{
+				KeyRingName:     types.String{Value: cmkData.GetGcpCmkSpec().KeyRingName},
+				KeyName:         types.String{Value: cmkData.GetGcpCmkSpec().KeyName},
+				Location:        types.String{Value: cmkData.GetGcpCmkSpec().Location},
+				ProtectionLevel: types.String{Value: cmkData.GetGcpCmkSpec().ProtectionLevel},
+			}
+			if cmkData.GetGcpCmkSpec().GcpServiceAccount != nil {
+				gcpServiceAccount := GCPServiceAccount{
+					Type:                    types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.Type},
+					ProjectId:               types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.ProjectId},
+					PrivateKeyId:            types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.PrivateKeyId},
+					ClientEmail:             types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.ClientEmail},
+					ClientId:                types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.ClientId},
+					AuthUri:                 types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.AuthUri},
+					TokenUri:                types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.TokenUri},
+					AuthProviderX509CertUrl: types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.AuthProviderX509CertUrl},
+					ClientX509CertUrl:       types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.ClientX509CertUrl},
+				}
+				if cmkData.GetGcpCmkSpec().GcpServiceAccount.GetPrivateKey() != "" {
+					privateKey := types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.GetPrivateKey()}
+					gcpServiceAccount.PrivateKey = privateKey
+				}
+				if cmkData.GetGcpCmkSpec().GcpServiceAccount.GetUniverseDomain() != "" {
+					universeDomain := types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.GetUniverseDomain()}
+					gcpServiceAccount.UniverseDomain = universeDomain
+				}
+				gcpCMKSpec.GcpServiceAccount = gcpServiceAccount
+			}
+
+			cmkSpec.GCPCMKSpec = &gcpCMKSpec
+			cluster.CMKSpec = &cmkSpec
 		}
 	}
 
@@ -1208,6 +1503,22 @@ func (r resourceCluster) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 		backUpSchedules = append(backUpSchedules, backupScheduleStruct)
 
 	}
+
+	if plan.CMKSpec != nil {
+		cmkSpecNew, cmkSpecOK, errorMessage := createCmkSpec(plan)
+		if cmkSpecOK {
+			_, res, err := apiClient.ClusterApi.EditClusterCMK(context.Background(), accountId, projectId, clusterId).CMKSpec(*cmkSpecNew).Execute()
+			if err != nil {
+				errorMessage := getErrorMessage(res, err)
+				resp.Diagnostics.AddError("Unable to update cluster CMK", errorMessage)
+				return
+			}
+		} else {
+			resp.Diagnostics.AddError("Unable to create CMK spec", errorMessage)
+			return
+		}
+	}
+
 	allowListIDs := []string{}
 	allowListProvided := false
 
@@ -1267,6 +1578,19 @@ func (r resourceCluster) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 	}
 	tflog.Debug(ctx, "Cluster Update: Allow list IDs read from API server ", map[string]interface{}{
 		"Allow List IDs": cluster.ClusterAllowListIDs})
+
+	// Update the State file with the unmasked creds for AWS (secret key,access) and GCP (client id,private key)
+	if plan.CMKSpec != nil {
+		providerType := cluster.CMKSpec.ProviderType.Value
+		switch providerType {
+		case "AWS":
+			cluster.CMKSpec.AWSCMKSpec.SecretKey = plan.CMKSpec.AWSCMKSpec.SecretKey
+			cluster.CMKSpec.AWSCMKSpec.AccessKey = plan.CMKSpec.AWSCMKSpec.AccessKey
+		case "GCP":
+			cluster.CMKSpec.GCPCMKSpec.GcpServiceAccount.ClientId = plan.CMKSpec.GCPCMKSpec.GcpServiceAccount.ClientId
+			cluster.CMKSpec.GCPCMKSpec.GcpServiceAccount.PrivateKey = plan.CMKSpec.GCPCMKSpec.GcpServiceAccount.PrivateKey
+		}
+	}
 
 	// set credentials for cluster (not returned by read api)
 	req.State.GetAttribute(ctx, path.Root("credentials"), &cluster.Credentials)


### PR DESCRIPTION
Summary:

This PR adds encryption at rest support to Terraform.
1. Cluster creation with AWS CMK and GCP CMK 
2. Adding EAR to existing cluster 
3. Enable or disable EAR for existing EAR enabled cluster.

Testing:

Manually tested out all the scenarios.
