### PR TITLE
Fixed input validation and universe domain null issue for CMK 

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -361,6 +361,9 @@ Required:
 - `project_id` (String) GCP Project ID
 - `token_uri` (String) Token URI
 - `type` (String) Service Account Type
+
+Optional:
+
 - `universe_domain` (String) Google Universe Domain
 
 

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -610,6 +610,10 @@ func createCmkSpec(plan Cluster) (*openapiclient.CMKSpec, error) {
 	cmkProvider := plan.CMKSpec.ProviderType.Value
 	cmkSpec := openapiclient.NewCMKSpec(openapiclient.CMKProviderEnum(cmkProvider))
 
+	if plan.CMKSpec.GCPCMKSpec != nil && plan.CMKSpec.AWSCMKSpec != nil {
+		return nil, errors.New("Invalid input. Both AWS and GCP spec cannot be present")
+	}
+
 	switch cmkProvider {
 	case "GCP":
 		if plan.CMKSpec.GCPCMKSpec == nil {

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -249,7 +249,7 @@ and modify the backup schedule of the cluster being created.`,
 									"universe_domain": {
 										Description: "Google Universe Domain",
 										Type:        types.StringType,
-										Required:    true,
+										Optional:    true,
 									},
 								}),
 							},
@@ -1200,6 +1200,8 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 				if cmkData.GetGcpCmkSpec().GcpServiceAccount.GetUniverseDomain() != "" {
 					universeDomain := types.String{Value: cmkData.GetGcpCmkSpec().GcpServiceAccount.GetUniverseDomain()}
 					gcpServiceAccount.UniverseDomain = universeDomain
+				} else {
+					gcpServiceAccount.UniverseDomain.Null = true
 				}
 				gcpCMKSpec.GcpServiceAccount = gcpServiceAccount
 			}


### PR DESCRIPTION
Summary:
1. Input validation when both AWS and GCP CMK spec are given as present in cmk_spec. 
2. Supported null value when universe domain is not provided in GCP CMK Spec.

Testing:
Tested manually 