### PR TITLE
[CLOUDGA-15695] Add support for RF5/7

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -47,6 +47,7 @@ data "ybm_cluster" "example_cluster"{
 - `desired_state` (String) The desired state of the database, Active or Paused. This parameter can be used to pause/resume a cluster.
 - `fault_tolerance` (String) The fault tolerance of the cluster.
 - `node_config` (Attributes) (see [below for nested schema](#nestedatt--node_config))
+- `num_faults_to_tolerate` (Number) The number of domain faults the cluster can tolerate.
 - `project_id` (String) The ID of the project this cluster belongs to.
 - `restore_backup_id` (String) The ID of the backup to be restored to the cluster.
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -493,6 +493,7 @@ resource "ybm_private_service_endpoint" "npsenonok-region" {
 - `database_track` (String) The track of the database. Production or Innovation or Preview.
 - `desired_state` (String) The desired state of the database, Active or Paused. This parameter can be used to pause/resume a cluster.
 - `fault_tolerance` (String) The fault tolerance of the cluster. NONE, NODE, ZONE or REGION.
+- `num_faults_to_tolerate` (Number) The number of domain faults the cluster can tolerate. 0 for NONE, 1 for ZONE and [1-3] for NODE and REGION
 - `restore_backup_id` (String) The ID of the backup to be restored to the cluster.
 
 ### Read-Only

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -251,6 +251,11 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				Type:        types.StringType,
 				Computed:    true,
 			},
+			"num_faults_to_tolerate": {
+				Description: "The number of domain faults the cluster can tolerate.",
+				Type:        types.Int64Type,
+				Computed:    true,
+			},
 			"cluster_allow_list_ids": {
 				Description: "List of IDs of the allow lists assigned to the cluster.",
 				Type: types.ListType{

--- a/managed/models.go
+++ b/managed/models.go
@@ -16,6 +16,7 @@ type Cluster struct {
 	CloudType           types.String         `tfsdk:"cloud_type"`
 	ClusterType         types.String         `tfsdk:"cluster_type"`
 	FaultTolerance      types.String         `tfsdk:"fault_tolerance"`
+	NumFaultsToTolerate types.Int64          `tfsdk:"num_faults_to_tolerate"`
 	ClusterRegionInfo   []RegionInfo         `tfsdk:"cluster_region_info"`
 	DatabaseTrack       types.String         `tfsdk:"database_track"`
 	DesiredState        types.String         `tfsdk:"desired_state"`


### PR DESCRIPTION
This adds the required changes for being able to specify the number of faults to tolerate for configuring the replication factor of the cluster.