### PR TITLE
[CLOUDGA-17429] Add Azure CMK support to Terraform 

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -94,6 +94,7 @@ Read-Only:
 Read-Only:
 
 - `aws_cmk_spec` (Attributes) AWS CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--aws_cmk_spec))
+- `azure_cmk_spec` (Attributes) AZURE CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--azure_cmk_spec))
 - `gcp_cmk_spec` (Attributes) GCP CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--gcp_cmk_spec))
 - `is_enabled` (Boolean) Is Enabled
 - `provider_type` (String) CMK Provider Type.
@@ -106,6 +107,18 @@ Read-Only:
 - `access_key` (String) Access Key
 - `arn_list` (List of String) AWS ARN List
 - `secret_key` (String) Secret Key
+
+
+<a id="nestedatt--cmk_spec--azure_cmk_spec"></a>
+### Nested Schema for `cmk_spec.azure_cmk_spec`
+
+Read-Only:
+
+- `client_id` (String) Client ID
+- `client_secret` (String) Client Secret
+- `key_name` (String) Key Name
+- `key_vault_uri` (String) Key Vault URI
+- `tenant_id` (String) Tenant ID
 
 
 <a id="nestedatt--cmk_spec--gcp_cmk_spec"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -364,6 +364,7 @@ To create an AWS Cluster with Customer Managed Keys
 ```terraform
 # EAR enabled single region cluster
 # The same cmk_spec can be used for multi region/read replica clusters as well
+# Encryption at rest is supported on clusters with database version 2.16.7.0 or later
 
 variable "ysql_password" {
   type        = string
@@ -423,6 +424,7 @@ To create a GCP Cluster with Customer Managed Keys
 ```terraform
 # EAR enabled single region cluster
 # The same cmk_spec can be used for multi region/read replica clusters as well
+# Encryption at rest is supported on clusters with database version 2.16.7.0 or later
 
 variable "ysql_password" {
   type        = string
@@ -696,6 +698,7 @@ Required:
 Optional:
 
 - `aws_cmk_spec` (Attributes) AWS CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--aws_cmk_spec))
+- `azure_cmk_spec` (Attributes) AZURE CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--azure_cmk_spec))
 - `gcp_cmk_spec` (Attributes) GCP CMK Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec--gcp_cmk_spec))
 
 <a id="nestedatt--cmk_spec--aws_cmk_spec"></a>
@@ -706,6 +709,18 @@ Required:
 - `access_key` (String) Access Key
 - `arn_list` (List of String) AWS ARN List
 - `secret_key` (String) Secret Key
+
+
+<a id="nestedatt--cmk_spec--azure_cmk_spec"></a>
+### Nested Schema for `cmk_spec.azure_cmk_spec`
+
+Required:
+
+- `client_id` (String) Azure Active Directory (AD) Client ID for Key Vault service principal.
+- `client_secret` (String) Azure AD Client Secret for Key Vault service principal.
+- `key_name` (String) Name of cryptographic key in Azure Key Vault.
+- `key_vault_uri` (String) URI of Azure Key Vault storing cryptographic keys.
+- `tenant_id` (String) Azure AD Tenant ID for Key Vault service principal.
 
 
 <a id="nestedatt--cmk_spec--gcp_cmk_spec"></a>

--- a/examples/resources/ybm_cluster/single-region-aws-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-aws-cmk.tf
@@ -1,5 +1,6 @@
 # EAR enabled single region cluster
 # The same cmk_spec can be used for multi region/read replica clusters as well
+# Encryption at rest is supported on clusters with database version 2.16.7.0 or later
 
 variable "ysql_password" {
   type        = string

--- a/examples/resources/ybm_cluster/single-region-azure-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-azure-cmk.tf
@@ -15,8 +15,9 @@ variable "ycql_password" {
 }
 
 resource "ybm_cluster" "single_region" {
-  cluster_name = "test-cluster-with-gcp-cmk"
+  cluster_name = "test-cluster-with-azure-cmk"
   # The cloud provider for the cluster is indepedent of the CMK Provider
+  # eg. GCP cluster with AZURE CMK is supported
   cloud_type   = "GCP"
   cluster_type = "SYNCHRONOUS"
   cluster_region_info = [
@@ -28,29 +29,18 @@ resource "ybm_cluster" "single_region" {
   cluster_tier           = "PAID"
   # fault tolerance cannot be NONE for CMK enabled cluster
   fault_tolerance        = "ZONE"
-
   cmk_spec = {
-    provider_type = "GCP"
-    gcp_cmk_spec = {
-    location = "global"
-    key_ring_name = "example_cmk_key_ring"
-    key_name = "example_cmk_key"
-    protection_level = "software"
-    gcp_service_account = {
-        type = "service_account"
-        project_id = "your-project-id"
-        private_key_id = "your-private-key-id"
-        private_key = "-----BEGIN PRIVATE KEY-----\nYourPrivateRSAKey\n-----END PRIVATE KEY-----\n"
-        client_email = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
-        client_id = "your-client-id"
-        auth_uri = "https://accounts.google.com/o/oauth2/auth"
-        token_uri = "https://accounts.google.com/o/oauth2/token"
-        auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
-        client_x509_cert_url = "https://www.googleapis.com/.../your-service-account-email%40your-project-id.iam.gserviceaccount.com"
-        universe_domain = "googleapis.com"
-    }}
+    provider_type = "AZURE"
+    azure_cmk_spec = {
+      client_id = "your-client-id"
+      client_secret = "your-client-secret"
+      tenant_id = "your-tenant-id"
+      key_name = "your-key-name"
+      key_vault_uri = "your-key-vault-uri"
+    }
     is_enabled =  true
   }
+
   node_config = {
     num_cores    = 4
     disk_size_gb = 50

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230915211221-361825bc5618
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231030163130-9268a00de50c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230915211221-361825bc5618 h1:ubU9s9gJPqDVcl9ZFd6sXZWhvRWJtcgdG5WtVVn4WE4=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20230915211221-361825bc5618/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231030163130-9268a00de50c h1:MzOpYz9LCniKMUhWZOnp6kn8bda5zq8vQ0oI58akrtc=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20231030163130-9268a00de50c/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -242,6 +242,37 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 							},
 						}),
 					},
+					"azure_cmk_spec": {
+						Description: "AZURE CMK Provider Configuration.",
+						Computed:    true,
+						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+							"client_id": {
+								Description: "Client ID",
+								Type:        types.StringType,
+								Computed:    true,
+							},
+							"client_secret": {
+								Description: "Client Secret",
+								Type:        types.StringType,
+								Computed:    true,
+							},
+							"tenant_id": {
+								Description: "Tenant ID",
+								Type:        types.StringType,
+								Computed:    true,
+							},
+							"key_vault_uri": {
+								Description: "Key Vault URI",
+								Type:        types.StringType,
+								Computed:    true,
+							},
+							"key_name": {
+								Description: "Key Name",
+								Type:        types.StringType,
+								Computed:    true,
+							},
+						}),
+					},
 				}),
 			},
 			"cluster_tier": {

--- a/managed/models.go
+++ b/managed/models.go
@@ -41,10 +41,11 @@ type ClusterEndpoint struct {
 }
 
 type CMKSpec struct {
-	ProviderType types.String `tfsdk:"provider_type"`
-	AWSCMKSpec   *AWSCMKSpec  `tfsdk:"aws_cmk_spec"`
-	GCPCMKSpec   *GCPCMKSpec  `tfsdk:"gcp_cmk_spec"`
-	IsEnabled    types.Bool   `tfsdk:"is_enabled"`
+	ProviderType types.String  `tfsdk:"provider_type"`
+	AWSCMKSpec   *AWSCMKSpec   `tfsdk:"aws_cmk_spec"`
+	GCPCMKSpec   *GCPCMKSpec   `tfsdk:"gcp_cmk_spec"`
+	AzureCMKSpec *AzureCMKSpec `tfsdk:"azure_cmk_spec"`
+	IsEnabled    types.Bool    `tfsdk:"is_enabled"`
 }
 
 type AWSCMKSpec struct {
@@ -60,6 +61,15 @@ type GCPCMKSpec struct {
 	ProtectionLevel   types.String      `tfsdk:"protection_level"`
 	GcpServiceAccount GCPServiceAccount `tfsdk:"gcp_service_account"`
 }
+
+type AzureCMKSpec struct {
+	ClientID     types.String `tfsdk:"client_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+	TenantID     types.String `tfsdk:"tenant_id"`
+	KeyVaultUri  types.String `tfsdk:"key_vault_uri"`
+	KeyName      types.String `tfsdk:"key_name"`
+}
+
 type GCPServiceAccount struct {
 	Type                    types.String `tfsdk:"type"`
 	ProjectId               types.String `tfsdk:"project_id"`

--- a/managed/resource_backup.go
+++ b/managed/resource_backup.go
@@ -144,7 +144,7 @@ func (r resourceBackup) Create(ctx context.Context, req tfsdk.CreateResourceRequ
 	backupRetentionPeriodInDays := int32(plan.RetentionPeriodInDays.Value)
 
 	backupSpec := *openapiclient.NewBackupSpec(clusterId)
-	backupSpec.Description = &backupDescription
+	backupSpec.SetDescription(backupDescription)
 	backupSpec.RetentionPeriodInDays = &backupRetentionPeriodInDays
 
 	backupResp, response, err := apiClient.BackupApi.CreateBackup(context.Background(), accountId, projectId).BackupSpec(backupSpec).Execute()
@@ -203,7 +203,7 @@ func resourceBackupRead(accountId string, projectId string, backupId string, api
 	backup.BackupID.Value = backupId
 
 	backup.ClusterID.Value = backupResp.Data.Spec.ClusterId
-	backup.BackupDescription.Value = *(backupResp.Data.Spec.Description)
+	backup.BackupDescription.Value = *(backupResp.Data.Spec.Description.Get())
 	backup.RetentionPeriodInDays.Value = int64(*backupResp.Data.Spec.RetentionPeriodInDays)
 	backup.MostRecent.Null = true
 	backup.Timestamp.Null = true

--- a/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
+++ b/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
@@ -186,6 +186,36 @@ func (mr *MockAccountApiMockRecorder) GetAllowedLoginTypesExecute(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllowedLoginTypesExecute", reflect.TypeOf((*MockAccountApi)(nil).GetAllowedLoginTypesExecute), arg0)
 }
 
+// GetLoginRecords mocks base method.
+func (m *MockAccountApi) GetLoginRecords(arg0 context.Context, arg1 string) openapi.ApiGetLoginRecordsRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLoginRecords", arg0, arg1)
+	ret0, _ := ret[0].(openapi.ApiGetLoginRecordsRequest)
+	return ret0
+}
+
+// GetLoginRecords indicates an expected call of GetLoginRecords.
+func (mr *MockAccountApiMockRecorder) GetLoginRecords(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoginRecords", reflect.TypeOf((*MockAccountApi)(nil).GetLoginRecords), arg0, arg1)
+}
+
+// GetLoginRecordsExecute mocks base method.
+func (m *MockAccountApi) GetLoginRecordsExecute(arg0 openapi.ApiGetLoginRecordsRequest) (openapi.LoginRecordListResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLoginRecordsExecute", arg0)
+	ret0, _ := ret[0].(openapi.LoginRecordListResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetLoginRecordsExecute indicates an expected call of GetLoginRecordsExecute.
+func (mr *MockAccountApiMockRecorder) GetLoginRecordsExecute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoginRecordsExecute", reflect.TypeOf((*MockAccountApi)(nil).GetLoginRecordsExecute), arg0)
+}
+
 // InviteAccountUser mocks base method.
 func (m *MockAccountApi) InviteAccountUser(arg0 context.Context, arg1 string) openapi.ApiInviteAccountUserRequest {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Summary:

This PR adds support for Azure CMK:
1. Create a cluster with Azure CMK
2. Update state of Azure cmk
3. Enable/disable azure cmk

Additionally, also fixed a backupDescription related issue in this PR.

`
cannot use &backupDescription (value of type *string) as openapi.NullableString value in assignment
`
