### PR TITLE
[CLOUDGA-17071] Fix read replicas default multiZone value to true

### DIFF
--- a/managed/resource_read_replica.go
+++ b/managed/resource_read_replica.go
@@ -174,7 +174,7 @@ func createReadReplicasSpec(ctx context.Context, apiClient *openapiclient.APICli
 		placementInfo.SetVpcId(readReplica.VPCID.Value)
 
 		multiZone := true
-		if !readReplica.MultiZone.Null {
+		if !(readReplica.MultiZone.IsUnknown() || readReplica.MultiZone.IsNull()) {
 			multiZone = readReplica.MultiZone.Value
 		}
 		placementInfo.SetMultiZone(multiZone)


### PR DESCRIPTION
This PR fixes the default multiZone value to true, is the bool value is unknown. Verified locally that multiZone was earlier defaulting to `false`, and is defaulting to `true` post this fix.