### PR TITLE
[CLOUDGA-18070] Added support for asymmetric geo-partitioned clusters

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,14 @@ jobs:
             exit 1                                                                          
           fi                                                                                                 
         name: Check documentation
+      - run: |
+          make fmt-check
+          git status -s
+          if [[ -n $(git status -s) ]]; then
+            echo "The formatting is not proper. Please ensure that your run 'make fmt'"                                                                   
+            exit 1                                                                          
+          fi                                                                                                 
+        name: Check formatting
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,12 @@ update-client:
 
 clean:
 	rm -rf terraform-provider-ybm
+
+fmt:
+	go fmt ./...
+	terraform fmt --recursive
+	
+fmt-check:
+	@echo "Verifying formatting, failures can be fixed with 'make fmt'"
+	@!(gofmt -l -s -d . | grep '[a-z]')
+	terraform fmt -check --recursive

--- a/docs/data-sources/backup.md
+++ b/docs/data-sources/backup.md
@@ -13,7 +13,7 @@ The data source to fetch the backup ID and other information about the most rece
 
 ```terraform
 data "ybm_backup" "example_backup" {
-  cluster_id = "example-cluster-id"
+  cluster_id  = "example-cluster-id"
   most_recent = true
 }
 ```

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -12,7 +12,7 @@ The data source to fetch the cluster ID and other information about a cluster gi
 ## Example Usage
 
 ```terraform
-data "ybm_cluster" "example_cluster"{
+data "ybm_cluster" "example_cluster" {
   cluster_name = "example-cluster"
 }
 ```

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -82,6 +82,9 @@ Read-Only:
 
 Read-Only:
 
+- `disk_iops` (Number)
+- `disk_size_gb` (Number)
+- `num_cores` (Number)
 - `num_nodes` (Number)
 - `public_access` (Boolean)
 - `region` (String)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,9 +26,9 @@ variable "auth_token" {
 }
 
 provider "ybm" {
-  host = "cloud.yugabyte.com"
+  host            = "cloud.yugabyte.com"
   use_secure_host = false # True by default
-  auth_token = var.auth_token
+  auth_token      = var.auth_token
 }
 ```
 

--- a/docs/resources/allow_list.md
+++ b/docs/resources/allow_list.md
@@ -13,9 +13,9 @@ The resource to create an allow list in YugabyteDB Managed.
 
 ```terraform
 resource "ybm_allow_list" "example_allow_list" {
-  allow_list_name = "allow-all"
+  allow_list_name        = "allow-all"
   allow_list_description = "allow all the ip addresses"
-  cidr_list = ["0.0.0.0/0"]  
+  cidr_list              = ["0.0.0.0/0"]
 }
 ```
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -15,11 +15,11 @@ To issue an API Key with predefined built-in roles like Admin, Developer, Viewer
 
 ```terraform
 resource "ybm_api_key" "example_api_key" {
-    name = "example-api-key-name"
-    description = "example API Key description" #Optional
-    duration = 10
-    unit = "Hours"
-    role_name = "Developer"
+  name        = "example-api-key-name"
+  description = "example API Key description" #Optional
+  duration    = 10
+  unit        = "Hours"
+  role_name   = "Developer"
 }
 ```
 
@@ -27,11 +27,11 @@ To issue an API Key with custom user defined roles
 
 ```terraform
 resource "ybm_api_key" "example_custom_role_api_key" {
-    name = "example-api-key-name"
-    description = "example API Key description" #Optional
-    duration = 1
-    unit = "Months"
-    role_name = "example-custom-role-name"
+  name        = "example-api-key-name"
+  description = "example API Key description" #Optional
+  duration    = 1
+  unit        = "Months"
+  role_name   = "example-custom-role-name"
 }
 ```
 

--- a/docs/resources/associate_metrics_exporter_cluster.md
+++ b/docs/resources/associate_metrics_exporter_cluster.md
@@ -13,9 +13,9 @@ The resource to associate a metrics exporter config to a cluster in YugabyteDB M
 
 ```terraform
 resource "ybm_associate_metrics_exporter_cluster" "metrics-srcluster" {
-  cluster_id= ybm_cluster.single_region_cluster.cluster_id
-  config_id = ybm_metrics_exporter.test.config_id
-  depends_on = [ ybm_cluster.single_region_cluster, ybm_metrics_exporter.test ]
+  cluster_id = ybm_cluster.single_region_cluster.cluster_id
+  config_id  = ybm_metrics_exporter.test.config_id
+  depends_on = [ybm_cluster.single_region_cluster, ybm_metrics_exporter.test]
 }
 ```
 

--- a/docs/resources/backup.md
+++ b/docs/resources/backup.md
@@ -15,9 +15,9 @@ The resource to create a manual backup of tables in a particular cluster.
 
 ```terraform
 resource "ybm_backup" "example_backup" {
-  cluster_id = "example-cluster-id"
-  backup_description = "example-backup-description"
-  retention_period_in_days = 2  
+  cluster_id               = "example-cluster-id"
+  backup_description       = "example-backup-description"
+  retention_period_in_days = 2
 }
 ```
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -270,7 +270,7 @@ resource "ybm_cluster" "multi_region_cluster" {
       vpc_id    = "example-vpc-id" #Optional
       #vpc_name = "example-vpc-name" #Optional You can also use the VPC Name in place of vpc_id
     }
-    
+
   ]
   cluster_tier           = "PAID"
   cluster_allow_list_ids = ["example-allow-list-id-1", "example-allow-list-id-2"] #Optional
@@ -390,9 +390,9 @@ resource "ybm_cluster" "single_region" {
       num_nodes = 6
     }
   ]
-  cluster_tier           = "PAID"
+  cluster_tier = "PAID"
   # fault tolerance cannot be NONE for CMK enabled cluster
-  fault_tolerance        = "ZONE"
+  fault_tolerance = "ZONE"
 
   cmk_spec = {
     provider_type = "AWS"
@@ -403,7 +403,7 @@ resource "ybm_cluster" "single_region" {
         "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
       ]
     }
-    is_enabled =  true
+    is_enabled = true
   }
 
   node_config = {
@@ -449,31 +449,31 @@ resource "ybm_cluster" "single_region" {
       num_nodes = 6
     }
   ]
-  cluster_tier           = "PAID"
+  cluster_tier = "PAID"
   # fault tolerance cannot be NONE for CMK enabled cluster
-  fault_tolerance        = "ZONE"
+  fault_tolerance = "ZONE"
 
   cmk_spec = {
     provider_type = "GCP"
     gcp_cmk_spec = {
-    location = "global"
-    key_ring_name = "example_cmk_key_ring"
-    key_name = "example_cmk_key"
-    protection_level = "software"
-    gcp_service_account = {
-        type = "service_account"
-        project_id = "your-project-id"
-        private_key_id = "your-private-key-id"
-        private_key = "-----BEGIN PRIVATE KEY-----\nYourPrivateRSAKey\n-----END PRIVATE KEY-----\n"
-        client_email = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
-        client_id = "your-client-id"
-        auth_uri = "https://accounts.google.com/o/oauth2/auth"
-        token_uri = "https://accounts.google.com/o/oauth2/token"
+      location         = "global"
+      key_ring_name    = "example_cmk_key_ring"
+      key_name         = "example_cmk_key"
+      protection_level = "software"
+      gcp_service_account = {
+        type                        = "service_account"
+        project_id                  = "your-project-id"
+        private_key_id              = "your-private-key-id"
+        private_key                 = "-----BEGIN PRIVATE KEY-----\nYourPrivateRSAKey\n-----END PRIVATE KEY-----\n"
+        client_email                = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
+        client_id                   = "your-client-id"
+        auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
+        token_uri                   = "https://accounts.google.com/o/oauth2/token"
         auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
-        client_x509_cert_url = "https://www.googleapis.com/.../your-service-account-email%40your-project-id.iam.gserviceaccount.com"
-        universe_domain = "googleapis.com"
-    }}
-    is_enabled =  true
+        client_x509_cert_url        = "https://www.googleapis.com/.../your-service-account-email%40your-project-id.iam.gserviceaccount.com"
+        universe_domain             = "googleapis.com"
+    } }
+    is_enabled = true
   }
   node_config = {
     num_cores    = 4

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -643,6 +643,9 @@ Required:
 
 Optional:
 
+- `disk_iops` (Number) Disk IOPS of the nodes of the region.
+- `disk_size_gb` (Number) Disk size of the nodes of the region.
+- `num_cores` (Number) Number of CPU cores in the nodes of the region.
 - `public_access` (Boolean)
 - `vpc_id` (String)
 - `vpc_name` (String)

--- a/docs/resources/read_replicas.md
+++ b/docs/resources/read_replicas.md
@@ -15,15 +15,15 @@ The resource to create read replicas of a particular cluster. You can create mul
 
 ```terraform
 resource "ybm_read_replicas" "example_read_replica" {
-  read_replicas_info = [ 
+  read_replicas_info = [
     {
-      cloud_type = "GCP"
+      cloud_type   = "GCP"
       num_replicas = 1
-      num_nodes = 1
-      region = "us-east4"
-      vpc_id = "example-vpc-id"
+      num_nodes    = 1
+      region       = "us-east4"
+      vpc_id       = "example-vpc-id"
       node_config = {
-        num_cores = 2
+        num_cores    = 2
         disk_size_gb = 10
       }
     }

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -13,18 +13,18 @@ The resource to create a custom role in YugabyteDB Managed.
 
 ```terraform
 resource "ybm_role" "example_role" {
-    role_name = "example_role_name"
-    role_description = "example_role_description" #Optional
-    permission_list = [
-        {
-            resource_type = "CLUSTER"
-            operation_groups = ["READ"]
-        },
-        {
-            resource_type = "READ_REPLICA"
-            operation_groups = ["READ", "CREATE"]
-        }
-    ]
+  role_name        = "example_role_name"
+  role_description = "example_role_description" #Optional
+  permission_list = [
+    {
+      resource_type    = "CLUSTER"
+      operation_groups = ["READ"]
+    },
+    {
+      resource_type    = "READ_REPLICA"
+      operation_groups = ["READ", "CREATE"]
+    }
+  ]
 }
 ```
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -15,8 +15,8 @@ To invite a user with predefined built-in roles like Admin, Developer, Viewer
 
 ```terraform
 resource "ybm_user" "example_user" {
-    email = "example@example.com"
-    role_name = "Developer"
+  email     = "example@example.com"
+  role_name = "Developer"
 }
 ```
 
@@ -24,8 +24,8 @@ To invite a user with custom user defined roles
 
 ```terraform
 resource "ybm_user" "example_custom_role_user" {
-    email = "example@example.com"
-    role_name = "example-custom-role-name"
+  email     = "example@example.com"
+  role_name = "example-custom-role-name"
 }
 ```
 

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -13,7 +13,7 @@ The resource to create a VPC in YugabyteDB Managed.
 
 ```terraform
 resource "ybm_vpc" "example-vpc" {
-  name = "example-vpc"
+  name  = "example-vpc"
   cloud = "GCP"
   # Use only one of either global cidr or region cidr
   global_cidr = "10.9.0.0/18"
@@ -34,12 +34,12 @@ resource "ybm_vpc" "example-vpc" {
 
 ```terraform
 resource "ybm_vpc" "example-vpc" {
-  name = "example-vpc"
+  name  = "example-vpc"
   cloud = "AWS"
   region_cidr_info = [
     {
       region = "us-east-1"
-      cidr = "10.231.0.0/24"
+      cidr   = "10.231.0.0/24"
     }
   ]
 }
@@ -49,7 +49,7 @@ resource "ybm_vpc" "example-vpc" {
 
 ```terraform
 resource "ybm_vpc" "example-vpc" {
-  name = "example-vpc"
+  name  = "example-vpc"
   cloud = "AZURE"
   region_cidr_info = [
     {

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -15,25 +15,25 @@ The resource to create a VPC peering in YugabyteDB Managed.
 #AWS VPC Peering
 
 resource "ybm_vpc_peering" "example_vpc_peering" {
-  name = "example_name"
+  name              = "example_name"
   yugabytedb_vpc_id = "example_vpc_id"
   application_vpc_info = {
-    cloud = "AWS"
+    cloud      = "AWS"
     account_id = "example_account_id"
-    region = "us-west1"
-    vpc_id = "application_vpc_id"
-    cidr = "example_cidr"
+    region     = "us-west1"
+    vpc_id     = "application_vpc_id"
+    cidr       = "example_cidr"
   }
 }
 
 #GCP VPC Peering
 resource "ybm_vpc_peering" "example_vpc_peering" {
-  name = "example_name"
+  name              = "example_name"
   yugabytedb_vpc_id = "example_vpc_id"
   application_vpc_info = {
-    cloud = "GCP"
+    cloud   = "GCP"
     project = "example_project"
-    vpc_id = "application_vpc_id"
+    vpc_id  = "application_vpc_id"
   }
 }
 ```

--- a/examples/data-sources/ybm_backup/data-source.tf
+++ b/examples/data-sources/ybm_backup/data-source.tf
@@ -1,5 +1,5 @@
 
 data "ybm_backup" "example_backup" {
-  cluster_id = "example-cluster-id"
+  cluster_id  = "example-cluster-id"
   most_recent = true
 }

--- a/examples/data-sources/ybm_cluster/data-source.tf
+++ b/examples/data-sources/ybm_cluster/data-source.tf
@@ -1,3 +1,3 @@
-data "ybm_cluster" "example_cluster"{
+data "ybm_cluster" "example_cluster" {
   cluster_name = "example-cluster"
-} 
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -5,7 +5,7 @@ variable "auth_token" {
 }
 
 provider "ybm" {
-  host = "cloud.yugabyte.com"
+  host            = "cloud.yugabyte.com"
   use_secure_host = false # True by default
-  auth_token = var.auth_token
+  auth_token      = var.auth_token
 }

--- a/examples/resources/ybm_allow_list/resource.tf
+++ b/examples/resources/ybm_allow_list/resource.tf
@@ -1,5 +1,5 @@
 resource "ybm_allow_list" "example_allow_list" {
-  allow_list_name = "allow-all"
+  allow_list_name        = "allow-all"
   allow_list_description = "allow all the ip addresses"
-  cidr_list = ["0.0.0.0/0"]  
+  cidr_list              = ["0.0.0.0/0"]
 }

--- a/examples/resources/ybm_api_key/built-in-role-api-key.tf
+++ b/examples/resources/ybm_api_key/built-in-role-api-key.tf
@@ -1,7 +1,7 @@
 resource "ybm_api_key" "example_api_key" {
-    name = "example-api-key-name"
-    description = "example API Key description" #Optional
-    duration = 10
-    unit = "Hours"
-    role_name = "Developer"
+  name        = "example-api-key-name"
+  description = "example API Key description" #Optional
+  duration    = 10
+  unit        = "Hours"
+  role_name   = "Developer"
 }

--- a/examples/resources/ybm_api_key/custom-role-api-key.tf
+++ b/examples/resources/ybm_api_key/custom-role-api-key.tf
@@ -1,7 +1,7 @@
 resource "ybm_api_key" "example_custom_role_api_key" {
-    name = "example-api-key-name"
-    description = "example API Key description" #Optional
-    duration = 1
-    unit = "Months"
-    role_name = "example-custom-role-name"
+  name        = "example-api-key-name"
+  description = "example API Key description" #Optional
+  duration    = 1
+  unit        = "Months"
+  role_name   = "example-custom-role-name"
 }

--- a/examples/resources/ybm_associate_metrics_exporter_cluster/resource.tf
+++ b/examples/resources/ybm_associate_metrics_exporter_cluster/resource.tf
@@ -1,5 +1,5 @@
 resource "ybm_associate_metrics_exporter_cluster" "metrics-srcluster" {
-  cluster_id= ybm_cluster.single_region_cluster.cluster_id
-  config_id = ybm_metrics_exporter.test.config_id
-  depends_on = [ ybm_cluster.single_region_cluster, ybm_metrics_exporter.test ]
+  cluster_id = ybm_cluster.single_region_cluster.cluster_id
+  config_id  = ybm_metrics_exporter.test.config_id
+  depends_on = [ybm_cluster.single_region_cluster, ybm_metrics_exporter.test]
 }

--- a/examples/resources/ybm_backup/resource.tf
+++ b/examples/resources/ybm_backup/resource.tf
@@ -1,5 +1,5 @@
 resource "ybm_backup" "example_backup" {
-  cluster_id = "example-cluster-id"
-  backup_description = "example-backup-description"
-  retention_period_in_days = 2  
+  cluster_id               = "example-cluster-id"
+  backup_description       = "example-backup-description"
+  retention_period_in_days = 2
 }

--- a/examples/resources/ybm_cluster/asymmetric-geo-partitioned.tf
+++ b/examples/resources/ybm_cluster/asymmetric-geo-partitioned.tf
@@ -4,49 +4,42 @@ variable "password" {
   sensitive   = true
 }
 
-# Multi Region Cluster
-resource "ybm_cluster" "multi_region_cluster" {
-  cluster_name = "multi-region-cluster"
+# Asymmetric Geo Partitioned Cluster
+# Creates 3 regions us-west1/asia-east1/europe-central2 with num_cores as 2/4/4 respectively
+resource "ybm_cluster" "asymmetric_geo_partitioned_cluster" {
+  cluster_name = "asymmetric-geo-partitioned-cluster"
   cloud_type   = "GCP"
-  cluster_type = "SYNCHRONOUS"
+  cluster_type = "GEO_PARTITIONED"
   cluster_region_info = [
     {
-      region    = "us-west1"
-      num_nodes = 1
-      vpc_id    = "example-vpc-id" #Optional
+      region       = "us-west1"
+      num_nodes    = 1
+      num_cores    = 2
+      disk_size_gb = 50               #Optional
+      vpc_id       = "example-vpc-id" #Optional
       #vpc_name = "example-vpc-name" #Optional You can also use the VPC Name in place of vpc_id
     },
     {
-      region    = "asia-east1"
-      num_nodes = 1
-      vpc_id    = "example-vpc-id" #Optional
+      region       = "asia-east1"
+      num_nodes    = 1
+      num_cores    = 4
+      disk_size_gb = 100              #Optional
+      vpc_id       = "example-vpc-id" #Optional
       #vpc_name = "example-vpc-name" #Optional You can also use the VPC Name in place of vpc_id
     },
     {
-      region    = "europe-central2"
-      num_nodes = 1
-      vpc_id    = "example-vpc-id" #Optional
-      #vpc_name = "example-vpc-name" #Optional You can also use the VPC Name in place of vpc_id
-    },
-    {
-      region    = "us-east1"
-      num_nodes = 1
-      vpc_id    = "example-vpc-id" #Optional
-      #vpc_name = "example-vpc-name" #Optional You can also use the VPC Name in place of vpc_id
-    },
-    {
-      region    = "us-west4"
-      num_nodes = 1
-      vpc_id    = "example-vpc-id" #Optional
+      region       = "europe-central2"
+      num_nodes    = 1
+      num_cores    = 4
+      disk_size_gb = 100              # Optional
+      vpc_id       = "example-vpc-id" #Optional
       #vpc_name = "example-vpc-name" #Optional You can also use the VPC Name in place of vpc_id
     }
-
   ]
   cluster_tier           = "PAID"
   cluster_allow_list_ids = ["example-allow-list-id-1", "example-allow-list-id-2"] #Optional
   restore_backup_id      = "example-backup-id"                                    #Optional
   fault_tolerance        = "REGION"
-  num_faults_to_tolerate = 2
   node_config = {
     num_cores    = 2
     disk_size_gb = 50 #Optional
@@ -63,4 +56,3 @@ resource "ybm_cluster" "multi_region_cluster" {
     password = var.password
   }
 }
-

--- a/examples/resources/ybm_cluster/single-region-aws-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-aws-cmk.tf
@@ -26,9 +26,9 @@ resource "ybm_cluster" "single_region" {
       num_nodes = 6
     }
   ]
-  cluster_tier           = "PAID"
+  cluster_tier = "PAID"
   # fault tolerance cannot be NONE for CMK enabled cluster
-  fault_tolerance        = "ZONE"
+  fault_tolerance = "ZONE"
 
   cmk_spec = {
     provider_type = "AWS"
@@ -39,7 +39,7 @@ resource "ybm_cluster" "single_region" {
         "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
       ]
     }
-    is_enabled =  true
+    is_enabled = true
   }
 
   node_config = {

--- a/examples/resources/ybm_cluster/single-region-azure-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-azure-cmk.tf
@@ -26,19 +26,19 @@ resource "ybm_cluster" "single_region" {
       num_nodes = 6
     }
   ]
-  cluster_tier           = "PAID"
+  cluster_tier = "PAID"
   # fault tolerance cannot be NONE for CMK enabled cluster
-  fault_tolerance        = "ZONE"
+  fault_tolerance = "ZONE"
   cmk_spec = {
     provider_type = "AZURE"
     azure_cmk_spec = {
-      client_id = "your-client-id"
+      client_id     = "your-client-id"
       client_secret = "your-client-secret"
-      tenant_id = "your-tenant-id"
-      key_name = "your-key-name"
+      tenant_id     = "your-tenant-id"
+      key_name      = "your-key-name"
       key_vault_uri = "your-key-vault-uri"
     }
-    is_enabled =  true
+    is_enabled = true
   }
 
   node_config = {

--- a/examples/resources/ybm_cluster/single-region-gcp-cmk.tf
+++ b/examples/resources/ybm_cluster/single-region-gcp-cmk.tf
@@ -25,31 +25,31 @@ resource "ybm_cluster" "single_region" {
       num_nodes = 6
     }
   ]
-  cluster_tier           = "PAID"
+  cluster_tier = "PAID"
   # fault tolerance cannot be NONE for CMK enabled cluster
-  fault_tolerance        = "ZONE"
+  fault_tolerance = "ZONE"
 
   cmk_spec = {
     provider_type = "GCP"
     gcp_cmk_spec = {
-    location = "global"
-    key_ring_name = "example_cmk_key_ring"
-    key_name = "example_cmk_key"
-    protection_level = "software"
-    gcp_service_account = {
-        type = "service_account"
-        project_id = "your-project-id"
-        private_key_id = "your-private-key-id"
-        private_key = "-----BEGIN PRIVATE KEY-----\nYourPrivateRSAKey\n-----END PRIVATE KEY-----\n"
-        client_email = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
-        client_id = "your-client-id"
-        auth_uri = "https://accounts.google.com/o/oauth2/auth"
-        token_uri = "https://accounts.google.com/o/oauth2/token"
+      location         = "global"
+      key_ring_name    = "example_cmk_key_ring"
+      key_name         = "example_cmk_key"
+      protection_level = "software"
+      gcp_service_account = {
+        type                        = "service_account"
+        project_id                  = "your-project-id"
+        private_key_id              = "your-private-key-id"
+        private_key                 = "-----BEGIN PRIVATE KEY-----\nYourPrivateRSAKey\n-----END PRIVATE KEY-----\n"
+        client_email                = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
+        client_id                   = "your-client-id"
+        auth_uri                    = "https://accounts.google.com/o/oauth2/auth"
+        token_uri                   = "https://accounts.google.com/o/oauth2/token"
         auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
-        client_x509_cert_url = "https://www.googleapis.com/.../your-service-account-email%40your-project-id.iam.gserviceaccount.com"
-        universe_domain = "googleapis.com"
-    }}
-    is_enabled =  true
+        client_x509_cert_url        = "https://www.googleapis.com/.../your-service-account-email%40your-project-id.iam.gserviceaccount.com"
+        universe_domain             = "googleapis.com"
+    } }
+    is_enabled = true
   }
   node_config = {
     num_cores    = 4

--- a/examples/resources/ybm_read_replicas/resource.tf
+++ b/examples/resources/ybm_read_replicas/resource.tf
@@ -1,13 +1,13 @@
 resource "ybm_read_replicas" "example_read_replica" {
-  read_replicas_info = [ 
+  read_replicas_info = [
     {
-      cloud_type = "GCP"
+      cloud_type   = "GCP"
       num_replicas = 1
-      num_nodes = 1
-      region = "us-east4"
-      vpc_id = "example-vpc-id"
+      num_nodes    = 1
+      region       = "us-east4"
+      vpc_id       = "example-vpc-id"
       node_config = {
-        num_cores = 2
+        num_cores    = 2
         disk_size_gb = 10
       }
     }

--- a/examples/resources/ybm_role/resource.tf
+++ b/examples/resources/ybm_role/resource.tf
@@ -1,14 +1,14 @@
 resource "ybm_role" "example_role" {
-    role_name = "example_role_name"
-    role_description = "example_role_description" #Optional
-    permission_list = [
-        {
-            resource_type = "CLUSTER"
-            operation_groups = ["READ"]
-        },
-        {
-            resource_type = "READ_REPLICA"
-            operation_groups = ["READ", "CREATE"]
-        }
-    ]
+  role_name        = "example_role_name"
+  role_description = "example_role_description" #Optional
+  permission_list = [
+    {
+      resource_type    = "CLUSTER"
+      operation_groups = ["READ"]
+    },
+    {
+      resource_type    = "READ_REPLICA"
+      operation_groups = ["READ", "CREATE"]
+    }
+  ]
 }

--- a/examples/resources/ybm_user/built-in-role-user.tf
+++ b/examples/resources/ybm_user/built-in-role-user.tf
@@ -1,4 +1,4 @@
 resource "ybm_user" "example_user" {
-    email = "example@example.com"
-    role_name = "Developer"
+  email     = "example@example.com"
+  role_name = "Developer"
 }

--- a/examples/resources/ybm_user/custom-role-user.tf
+++ b/examples/resources/ybm_user/custom-role-user.tf
@@ -1,4 +1,4 @@
 resource "ybm_user" "example_custom_role_user" {
-    email = "example@example.com"
-    role_name = "example-custom-role-name"
+  email     = "example@example.com"
+  role_name = "example-custom-role-name"
 }

--- a/examples/resources/ybm_vpc/aws-regional-vpc.tf
+++ b/examples/resources/ybm_vpc/aws-regional-vpc.tf
@@ -1,10 +1,10 @@
 resource "ybm_vpc" "example-vpc" {
-  name = "example-vpc"
+  name  = "example-vpc"
   cloud = "AWS"
   region_cidr_info = [
     {
       region = "us-east-1"
-      cidr = "10.231.0.0/24"
+      cidr   = "10.231.0.0/24"
     }
   ]
 }

--- a/examples/resources/ybm_vpc/azure-vpc.tf
+++ b/examples/resources/ybm_vpc/azure-vpc.tf
@@ -1,5 +1,5 @@
 resource "ybm_vpc" "example-vpc" {
-  name = "example-vpc"
+  name  = "example-vpc"
   cloud = "AZURE"
   region_cidr_info = [
     {

--- a/examples/resources/ybm_vpc/gcp-global-cidr.tf
+++ b/examples/resources/ybm_vpc/gcp-global-cidr.tf
@@ -1,5 +1,5 @@
 resource "ybm_vpc" "example-vpc" {
-  name = "example-vpc"
+  name  = "example-vpc"
   cloud = "GCP"
   # Use only one of either global cidr or region cidr
   global_cidr = "10.9.0.0/18"

--- a/examples/resources/ybm_vpc_peering/resource.tf
+++ b/examples/resources/ybm_vpc_peering/resource.tf
@@ -1,24 +1,24 @@
 #AWS VPC Peering
 
 resource "ybm_vpc_peering" "example_vpc_peering" {
-  name = "example_name"
+  name              = "example_name"
   yugabytedb_vpc_id = "example_vpc_id"
   application_vpc_info = {
-    cloud = "AWS"
+    cloud      = "AWS"
     account_id = "example_account_id"
-    region = "us-west1"
-    vpc_id = "application_vpc_id"
-    cidr = "example_cidr"
+    region     = "us-west1"
+    vpc_id     = "application_vpc_id"
+    cidr       = "example_cidr"
   }
 }
 
 #GCP VPC Peering
 resource "ybm_vpc_peering" "example_vpc_peering" {
-  name = "example_name"
+  name              = "example_name"
   yugabytedb_vpc_id = "example_vpc_id"
   application_vpc_info = {
-    cloud = "GCP"
+    cloud   = "GCP"
     project = "example_project"
-    vpc_id = "application_vpc_id"
+    vpc_id  = "application_vpc_id"
   }
 }

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -64,6 +64,18 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 						Type:     types.StringType,
 						Computed: true,
 					},
+					"num_cores": {
+						Type:     types.Int64Type,
+						Computed: true,
+					},
+					"disk_size_gb": {
+						Type:     types.Int64Type,
+						Computed: true,
+					},
+					"disk_iops": {
+						Type:     types.Int64Type,
+						Computed: true,
+					},
 					"vpc_id": {
 						Type:     types.StringType,
 						Computed: true,

--- a/managed/models.go
+++ b/managed/models.go
@@ -96,6 +96,9 @@ type BackupScheduleInfo struct {
 type RegionInfo struct {
 	Region       types.String `tfsdk:"region"`
 	NumNodes     types.Int64  `tfsdk:"num_nodes"`
+	NumCores     types.Int64  `tfsdk:"num_cores"`
+	DiskSizeGb   types.Int64  `tfsdk:"disk_size_gb"`
+	DiskIops     types.Int64  `tfsdk:"disk_iops"`
 	VPCID        types.String `tfsdk:"vpc_id"`
 	VPCName      types.String `tfsdk:"vpc_name"`
 	PublicAccess types.Bool   `tfsdk:"public_access"`

--- a/samples/cluster-multi-region.tf
+++ b/samples/cluster-multi-region.tf
@@ -1,30 +1,30 @@
 resource "ybm_cluster" "multi_region" {
   cluster_name = "terraform-test-posriniv-3"
-  cloud_type = "GCP"
+  cloud_type   = "GCP"
   cluster_type = "SYNCHRONOUS"
   cluster_region_info = [
     {
-      region = "us-west2"
+      region    = "us-west2"
       num_nodes = 1
-      vpc_id = ybm_vpc.newvpc.vpc_id
+      vpc_id    = ybm_vpc.newvpc.vpc_id
     },
     {
-      region = "asia-east1"
+      region    = "asia-east1"
       num_nodes = 1
-      vpc_id = ybm_vpc.newvpc.vpc_id
+      vpc_id    = ybm_vpc.newvpc.vpc_id
     },
     {
-      region = "europe-central2"
+      region    = "europe-central2"
       num_nodes = 1
-      vpc_id = ybm_vpc.newvpc.vpc_id
+      vpc_id    = ybm_vpc.newvpc.vpc_id
     }
   ]
-  cluster_tier = "PAID"
+  cluster_tier           = "PAID"
   cluster_allow_list_ids = [ybm_allow_list.mylist.allow_list_id]
-  restore_backup_id = ybm_backup.mybackup.backup_id
-  fault_tolerance = "REGION"
+  restore_backup_id      = ybm_backup.mybackup.backup_id
+  fault_tolerance        = "REGION"
   node_config = {
-    num_cores = 2
+    num_cores    = 2
     disk_size_gb = 10
   }
   credentials = {

--- a/samples/cluster-single-region.tf
+++ b/samples/cluster-single-region.tf
@@ -92,8 +92,8 @@ resource "ybm_allow_list" "mylist" {
 
 
 resource "ybm_vpc" "newvpc" {
-  name       = "terraform-vpc"
-  cloud      = "GCP"
+  name  = "terraform-vpc"
+  cloud = "GCP"
   # Use only one among global cidr and region cidr
   global_cidr = "10.9.0.0/18"
   # region_cidr_info = [


### PR DESCRIPTION
For adding support for asymmetric geo-partitioned clusters, this PR adds optional per-region node fields `num_cores`, `disk_size_gb` and `disk_iops` to the existing attribute list `cluster_region_info`.

- If these per-region node fields are specified, they will be included in the clusterSpec payload, thereby allowing asymmetric geo configurations
- If these optional per-region node fields are not specified, the built clusterSpec payload will not contain the `nodeInfo` object within `ClusterRegionInfo` list, and hence the cluster creation will use the root level node fields.
