### PR TITLE
Added support for update and delete db audit log config resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240227102420-46f022634f9a
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240227155346-92b9a76dbeb3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240222125501-
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240222125501-26c4599f5ab7/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240227102420-46f022634f9a h1:ZBuRNMdCtuqAp2uYwHfY2RfIga1NCzZ9dxLCzIdvjJs=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240227102420-46f022634f9a/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240227155346-92b9a76dbeb3 h1:RouLJLwoZfjoKZ8jV6sNvtPQvj02fSydKvJo9ioK3sY=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20240227155346-92b9a76dbeb3/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Summary
Added support for update and delete db audit log config resource 

## Test Plan
Manually simulated `Create`, `Read`, `Update`, `Delete` funcs for the respective resource. Working as expected