### PR TITLE
Added support for db query logging update & delete resource

### DIFF
--- a/managed/models.go
+++ b/managed/models.go
@@ -374,7 +374,6 @@ type DbQueryLoggingConfig struct {
 	AccountID       types.String `tfsdk:"account_id"`
 	ProjectID       types.String `tfsdk:"project_id"`
 	ClusterID       types.String `tfsdk:"cluster_id"`
-	ClusterName     types.String `tfsdk:"cluster_name"`
 	IntegrationName types.String `tfsdk:"integration_name"`
 	State           types.String `tfsdk:"state"`
 	ConfigID        types.String `tfsdk:"config_id"`


### PR DESCRIPTION
- Added support for db query logging update & delete resource.
- Remove required field `cluster_name`.
- Added `cluster_id` as required field for consistency with other resources.

```terraform
resource "ybm_database_query_logging" "dql_by" {
  cluster_id = "c2e9c74a-cbea-4ee9-95d1-1537bc85b4be"
  integration_name = "nuij"
  log_config = {
    log_min_duration_statement = 30,
    debug_print_plan = false,
    log_connections = true,
    log_disconnections = true,
    log_duration = true,
    log_error_verbosity = "DEFAULT",
    log_statement = "NONE",
    log_min_error_statement = "ERROR",
    log_line_prefix = "%m :%r :%u @ %d :[%p] : %a :"
  }
}
```