### PR TITLE
CLOUDGA-23240 change resource name for ybm_database_query_logging

### DIFF
--- a/managed/provider.go
+++ b/managed/provider.go
@@ -166,7 +166,7 @@ func (p *provider) GetResources(_ context.Context) (map[string]tfsdk.ResourceTyp
 
 	// Add DB Query logging resource only if the feature flag is enabled
 	if fflags.IsFeatureFlagEnabled(fflags.DB_QUERY_LOGGING) {
-		resources["ybm_database_query_logging"] = resourceDbQueryLoggingType{}
+		resources["ybm_db_query_logging"] = resourceDbQueryLoggingType{}
 	}
 
 	return resources, nil


### PR DESCRIPTION
CLOUDGA-23240 change resource name for ybm_database_query_logging to ybm_db_query_logging.
This is to make it consistent with CLI and audit logs resource name `ybm_db_audit_logging`.