### PR TITLE
[CLOUDGA-22303] Add support for integration type PROMETHEUS

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -122,7 +122,7 @@ Required:
 
 Required:
 
-- `endpoint` (String) Prometheus OTLP endpoint URL
+- `endpoint` (String) Prometheus OTLP endpoint URL e.g. http://prometheus.yourcompany.com/api/v1/otlp
 
 
 <a id="nestedatt--sumologic_spec"></a>

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -66,6 +66,7 @@ resource "ybm_integration" "sumologic" {
 - `datadog_spec` (Attributes) The specifications of a Datadog integration. (see [below for nested schema](#nestedatt--datadog_spec))
 - `googlecloud_spec` (Attributes) The specifications of a Google Cloud integration. (see [below for nested schema](#nestedatt--googlecloud_spec))
 - `grafana_spec` (Attributes) The specifications of a Grafana integration. (see [below for nested schema](#nestedatt--grafana_spec))
+- `prometheus_spec` (Attributes) The specifications of a Prometheus integration. (see [below for nested schema](#nestedatt--prometheus_spec))
 - `sumologic_spec` (Attributes) The specifications of a Sumo Logic integration. (see [below for nested schema](#nestedatt--sumologic_spec))
 
 ### Read-Only
@@ -114,6 +115,14 @@ Required:
 - `instance_id` (String) Grafana InstanceID.
 - `org_slug` (String) Grafana OrgSlug.
 - `zone` (String) Grafana Zone.
+
+
+<a id="nestedatt--prometheus_spec"></a>
+### Nested Schema for `prometheus_spec`
+
+Required:
+
+- `endpoint` (String) Prometheus OTLP endpoint URL
 
 
 <a id="nestedatt--sumologic_spec"></a>

--- a/managed/models.go
+++ b/managed/models.go
@@ -278,6 +278,10 @@ type DataDogSpec struct {
 	ApiKey types.String `tfsdk:"api_key"`
 }
 
+type PrometheusSpec struct {
+	Endpoint types.String `tfsdk:"endpoint"`
+}
+
 type GrafanaSpec struct {
 	AccessTokenPolicy types.String `tfsdk:"access_policy_token"`
 	Zone              types.String `tfsdk:"zone"`
@@ -354,6 +358,7 @@ type TelemetryProvider struct {
 	ConfigName      types.String       `tfsdk:"config_name"`
 	Type            types.String       `tfsdk:"type"`
 	DataDogSpec     *DataDogSpec       `tfsdk:"datadog_spec"`
+	PrometheusSpec  *PrometheusSpec    `tfsdk:"prometheus_spec"`
 	GrafanaSpec     *GrafanaSpec       `tfsdk:"grafana_spec"`
 	SumoLogicSpec   *SumoLogicSpec     `tfsdk:"sumologic_spec"`
 	GoogleCloudSpec *GCPServiceAccount `tfsdk:"googlecloud_spec"`

--- a/managed/resource_integration.go
+++ b/managed/resource_integration.go
@@ -86,7 +86,7 @@ func (r resourceIntegrationType) getSchemaAttributes() map[string]tfsdk.Attribut
 			Validators:  onlyContainsPath("prometheus_spec"),
 			Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 				"endpoint": {
-					Description: "Prometheus OTLP endpoint URL",
+					Description: "Prometheus OTLP endpoint URL e.g. http://prometheus.yourcompany.com/api/v1/otlp",
 					Type:        types.StringType,
 					Required:    true,
 				},


### PR DESCRIPTION
## Resource Definition
```terraform
resource "ybm_integration" "prometheus" {
  config_name = "prometheus-example"
  type        = "PROMETHEUS"
  prometheus_spec = {
    endpoint = "http://yourcompany.com/api/v1/otlp"
  }
}
```

## Terraform Plan
```shell
> tfp

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ybm_integration.prometheus will be created
  + resource "ybm_integration" "prometheus" {
      + account_id      = (known after apply)
      + config_id       = (known after apply)
      + config_name     = "prometheus-example"
      + is_valid        = (known after apply)
      + project_id      = (known after apply)
      + prometheus_spec = {
          + endpoint = "http://yourcompany.com/api/v1/otlp"
        }
      + type            = "PROMETHEUS"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

## Terraform Apply
```shell
> tfa -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ybm_integration.prometheus will be created
  + resource "ybm_integration" "prometheus" {
      + account_id      = (known after apply)
      + config_id       = (known after apply)
      + config_name     = "prometheus-example"
      + is_valid        = (known after apply)
      + project_id      = (known after apply)
      + prometheus_spec = {
          + endpoint = "http://yourcompany.com/api/v1/otlp"
        }
      + type            = "PROMETHEUS"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
ybm_integration.prometheus: Creating...
ybm_integration.prometheus: Creation complete after 3s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## Terraform State
```shell
> tf state show ybm_integration.prometheus
# ybm_integration.prometheus:
resource "ybm_integration" "prometheus" {
    account_id      = "3b98d883-1b63-40ce-a4d7-8dc2d6e0ba53"
    config_id       = "4200c8df-2fb6-4098-9239-b9f8b046d6c5"
    config_name     = "prometheus-example"
    is_valid        = true
    project_id      = "bebbcb6b-3927-4ac3-81ce-23bba0c75a2e"
    prometheus_spec = {
        endpoint = "http://yourcompany.com/api/v1/otlp"
    }
    type            = "PROMETHEUS"
}
```

## Terraform Destroy
```shell
> tf destroy -auto-approve
ybm_integration.prometheus: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ybm_integration.prometheus will be destroyed
  - resource "ybm_integration" "prometheus" {
      - account_id      = "3b98d883-1b63-40ce-a4d7-8dc2d6e0ba53" -> null
      - config_id       = "0ccc8e03-5742-4fac-92e8-443f4f233017" -> null
      - config_name     = "prometheus-example" -> null
      - is_valid        = true -> null
      - project_id      = "bebbcb6b-3927-4ac3-81ce-23bba0c75a2e" -> null
      - prometheus_spec = {
          - endpoint = "http://yourcompany.com/api/v1/otlp" -> null
        } -> null
      - type            = "PROMETHEUS" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
ybm_integration.prometheus: Destroying...
ybm_integration.prometheus: Destruction complete after 1s
```