### PR TITLE
[CLOUDGA-24745] Add support for integration type VICTORIAMETRICS

### DIFF
--- a/docs/data-sources/integration.md
+++ b/docs/data-sources/integration.md
@@ -33,8 +33,10 @@ data "ybm_integration" "example_name" {
 - `grafana_spec` (Attributes) The specifications of a Grafana integration. (see [below for nested schema](#nestedatt--grafana_spec))
 - `is_valid` (Boolean) Signifies whether the integration configuration is valid or not
 - `project_id` (String) The ID of the project this integration belongs to.
+- `prometheus_spec` (Attributes) The specifications of a Prometheus integration. (see [below for nested schema](#nestedatt--prometheus_spec))
 - `sumologic_spec` (Attributes) The specifications of a Sumo Logic integration. (see [below for nested schema](#nestedatt--sumologic_spec))
 - `type` (String) Defines different exporter destination types.
+- `victoriametrics_spec` (Attributes) The specifications of a VictoriaMetrics integration. (see [below for nested schema](#nestedatt--victoriametrics_spec))
 
 <a id="nestedatt--datadog_spec"></a>
 ### Nested Schema for `datadog_spec`
@@ -74,6 +76,14 @@ Read-Only:
 - `zone` (String) Grafana Zone.
 
 
+<a id="nestedatt--prometheus_spec"></a>
+### Nested Schema for `prometheus_spec`
+
+Read-Only:
+
+- `endpoint` (String) Prometheus OTLP endpoint URL e.g. http://prometheus.yourcompany.com/api/v1/otlp
+
+
 <a id="nestedatt--sumologic_spec"></a>
 ### Nested Schema for `sumologic_spec`
 
@@ -82,3 +92,11 @@ Read-Only:
 - `access_id` (String, Sensitive) Sumo Logic Access Key ID
 - `access_key` (String, Sensitive) Sumo Logic Access Key
 - `installation_token` (String, Sensitive) A Sumo Logic installation token to export telemetry to Grafana with
+
+
+<a id="nestedatt--victoriametrics_spec"></a>
+### Nested Schema for `victoriametrics_spec`
+
+Read-Only:
+
+- `endpoint` (String) VictoriaMetrics OTLP endpoint URL e.g. http://my-victoria-metrics-endpoint/opentelemetry

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -68,6 +68,7 @@ resource "ybm_integration" "sumologic" {
 - `grafana_spec` (Attributes) The specifications of a Grafana integration. (see [below for nested schema](#nestedatt--grafana_spec))
 - `prometheus_spec` (Attributes) The specifications of a Prometheus integration. (see [below for nested schema](#nestedatt--prometheus_spec))
 - `sumologic_spec` (Attributes) The specifications of a Sumo Logic integration. (see [below for nested schema](#nestedatt--sumologic_spec))
+- `victoriametrics_spec` (Attributes) The specifications of a VictoriaMetrics integration. (see [below for nested schema](#nestedatt--victoriametrics_spec))
 
 ### Read-Only
 
@@ -133,3 +134,11 @@ Required:
 - `access_id` (String, Sensitive) Sumo Logic Access Key ID
 - `access_key` (String, Sensitive) Sumo Logic Access Key
 - `installation_token` (String, Sensitive) A Sumo Logic installation token to export telemetry to Grafana with
+
+
+<a id="nestedatt--victoriametrics_spec"></a>
+### Nested Schema for `victoriametrics_spec`
+
+Required:
+
+- `endpoint` (String) VictoriaMetrics OTLP endpoint URL e.g. http://my-victoria-metrics-endpoint/opentelemetry

--- a/managed/data_source_integration.go
+++ b/managed/data_source_integration.go
@@ -70,6 +70,28 @@ func (r dataSourceIntegrationType) GetSchema(_ context.Context) (tfsdk.Schema, d
 					},
 				}),
 			},
+			"prometheus_spec": {
+				Description: "The specifications of a Prometheus integration.",
+				Computed:    true,
+				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+					"endpoint": {
+						Description: "Prometheus OTLP endpoint URL e.g. http://prometheus.yourcompany.com/api/v1/otlp",
+						Type:        types.StringType,
+						Computed:    true,
+					},
+				}),
+			},
+			"victoriametrics_spec": {
+				Description: "The specifications of a VictoriaMetrics integration.",
+				Computed:    true,
+				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+					"endpoint": {
+						Description: "VictoriaMetrics OTLP endpoint URL e.g. http://my-victoria-metrics-endpoint/opentelemetry",
+						Type:        types.StringType,
+						Computed:    true,
+					},
+				}),
+			},
 			"grafana_spec": {
 				Description: "The specifications of a Grafana integration.",
 				Computed:    true,
@@ -280,6 +302,14 @@ func dataSourceTelemetryProviderRead(accountId string, projectId string, configN
 		tp.DataDogSpec = &DataDogSpec{
 			ApiKey: types.String{Value: configSpec.DatadogSpec.Get().ApiKey},
 			Site:   types.String{Value: configSpec.DatadogSpec.Get().Site},
+		}
+	case openapiclient.TELEMETRYPROVIDERTYPEENUM_PROMETHEUS:
+		tp.PrometheusSpec = &PrometheusSpec{
+			Endpoint: types.String{Value: configSpec.PrometheusSpec.Get().Endpoint},
+		}
+	case openapiclient.TELEMETRYPROVIDERTYPEENUM_VICTORIAMETRICS:
+		tp.VictoriaMetricsSpec = &VictoriaMetricsSpec{
+			Endpoint: types.String{Value: configSpec.VictoriametricsSpec.Get().Endpoint},
 		}
 	case openapiclient.TELEMETRYPROVIDERTYPEENUM_GRAFANA:
 		grafanaSpec := configSpec.GetGrafanaSpec()

--- a/managed/models.go
+++ b/managed/models.go
@@ -282,6 +282,10 @@ type PrometheusSpec struct {
 	Endpoint types.String `tfsdk:"endpoint"`
 }
 
+type VictoriaMetricsSpec struct {
+	Endpoint types.String `tfsdk:"endpoint"`
+}
+
 type GrafanaSpec struct {
 	AccessTokenPolicy types.String `tfsdk:"access_policy_token"`
 	Zone              types.String `tfsdk:"zone"`
@@ -352,17 +356,18 @@ type LogSettings struct {
 }
 
 type TelemetryProvider struct {
-	AccountID       types.String       `tfsdk:"account_id"`
-	ProjectID       types.String       `tfsdk:"project_id"`
-	ConfigID        types.String       `tfsdk:"config_id"`
-	ConfigName      types.String       `tfsdk:"config_name"`
-	Type            types.String       `tfsdk:"type"`
-	DataDogSpec     *DataDogSpec       `tfsdk:"datadog_spec"`
-	PrometheusSpec  *PrometheusSpec    `tfsdk:"prometheus_spec"`
-	GrafanaSpec     *GrafanaSpec       `tfsdk:"grafana_spec"`
-	SumoLogicSpec   *SumoLogicSpec     `tfsdk:"sumologic_spec"`
-	GoogleCloudSpec *GCPServiceAccount `tfsdk:"googlecloud_spec"`
-	IsValid         types.Bool         `tfsdk:"is_valid"`
+	AccountID           types.String         `tfsdk:"account_id"`
+	ProjectID           types.String         `tfsdk:"project_id"`
+	ConfigID            types.String         `tfsdk:"config_id"`
+	ConfigName          types.String         `tfsdk:"config_name"`
+	Type                types.String         `tfsdk:"type"`
+	DataDogSpec         *DataDogSpec         `tfsdk:"datadog_spec"`
+	PrometheusSpec      *PrometheusSpec      `tfsdk:"prometheus_spec"`
+	VictoriaMetricsSpec *VictoriaMetricsSpec `tfsdk:"victoriametrics_spec"`
+	GrafanaSpec         *GrafanaSpec         `tfsdk:"grafana_spec"`
+	SumoLogicSpec       *SumoLogicSpec       `tfsdk:"sumologic_spec"`
+	GoogleCloudSpec     *GCPServiceAccount   `tfsdk:"googlecloud_spec"`
+	IsValid             types.Bool           `tfsdk:"is_valid"`
 }
 
 type LogConfig struct {


### PR DESCRIPTION
# Summary:
- Add support for integration type VICTORIAMETRICS.
- Add TF `data-source` support for both Prometheus & VictoriaMetrics.

## Resource Definition
```terraform
resource "ybm_integration" "victoriametrics" {
  config_name = "victoriametrics-example"
  type        = "VICTORIAMETRICS"
  victoriametrics_spec = {
    endpoint = "http://yourcompany.com/"
  }
}
```

## Terraform Plan
```shell
> tfp

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ybm_integration.victoriametrics will be created
  + resource "ybm_integration" "victoriametrics" {
      + account_id           = (known after apply)
      + config_id            = (known after apply)
      + config_name          = "victoriametrics-example"
      + is_valid             = (known after apply)
      + project_id           = (known after apply)
      + type                 = "VICTORIAMETRICS"
      + victoriametrics_spec = {
          + endpoint = "http://yourcompany.com/"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

## Terraform Apply
```shell
> tfa -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ybm_integration.victoriametrics will be created
  + resource "ybm_integration" "victoriametrics" {
      + account_id           = (known after apply)
      + config_id            = (known after apply)
      + config_name          = "victoriametrics-example"
      + is_valid             = (known after apply)
      + project_id           = (known after apply)
      + type                 = "VICTORIAMETRICS"
      + victoriametrics_spec = {
          + endpoint = "http://yourcompany.com/"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
ybm_integration.victoriametrics: Creating...
tf ybm_integration.victoriametrics: Creation complete after 3s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## Terraform State
```shell
> tf state show ybm_integration.victoriametrics
# ybm_integration.victoriametrics:
resource "ybm_integration" "victoriametrics" {
    account_id           = "3b98d883-1b63-40ce-a4d7-8dc2d6e0ba53"
    config_id            = "ea375d4e-7f70-49f5-a187-68d6df7c4bd9"
    config_name          = "victoriametrics-example"
    is_valid             = true
    project_id           = "bebbcb6b-3927-4ac3-81ce-23bba0c75a2e"
    type                 = "VICTORIAMETRICS"
    victoriametrics_spec = {
        endpoint = "http://yourcompany.com/"
    }
}
```

## Terraform Destroy
```shell
> tf destroy -auto-approve
ybm_integration.victoriametrics: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ybm_integration.victoriametrics will be destroyed
  - resource "ybm_integration" "victoriametrics" {
      - account_id           = "3b98d883-1b63-40ce-a4d7-8dc2d6e0ba53" -> null
      - config_id            = "60304dcb-9f44-4e0c-96bf-d9dc7f8b3375" -> null
      - config_name          = "victoriametrics-example" -> null
      - is_valid             = true -> null
      - project_id           = "bebbcb6b-3927-4ac3-81ce-23bba0c75a2e" -> null
      - type                 = "VICTORIAMETRICS" -> null
      - victoriametrics_spec = {
          - endpoint = "http://yourcompany.com/" -> null
        } -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
ybm_integration.victoriametrics: Destroying...
ybm_integration.victoriametrics: Destruction complete after 2s

Destroy complete! Resources: 1 destroyed.
```

### Data Source(Prometheus and Victoria Metrics):

#### Resource definition
```terraform
data "ybm_integration" "vm_existing_resource" {
  config_name = "victoriametrics-example"
}


resource "ybm_integration" "victoriametrics2" {
  config_name = "victoriametrics-ds"
  type        = "VICTORIAMETRICS"
  victoriametrics_spec = {
    endpoint = data.ybm_integration.vm_existing_resource.victoriametrics_spec.endpoint
  }
}
```

#### Terraform apply

```shell
> tfa -auto-approve
data.ybm_integration.example_name: Reading...
data.ybm_integration.example_name: Read complete after 3s
ybm_integration.victoriametrics: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ybm_integration.victoriametrics2 will be created
  + resource "ybm_integration" "victoriametrics2" {
      + account_id           = (known after apply)
      + config_id            = (known after apply)
      + config_name          = "victoriametrics-ds"
      + is_valid             = (known after apply)
      + project_id           = (known after apply)
      + type                 = "VICTORIAMETRICS"
      + victoriametrics_spec = {
          + endpoint = "http://yourcompany.com/"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
ybm_integration.victoriametrics2: Creating...
ybm_integration.victoriametrics2: Creation complete after 2s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
