### PR TITLE
[CLOUDGA-24855] Fix update DB Audit logging error 

### DIFF
--- a/managed/resource_db_audit_logging.go
+++ b/managed/resource_db_audit_logging.go
@@ -418,6 +418,13 @@ func (r resourceDbAuditLogging) Update(ctx context.Context, req tfsdk.UpdateReso
 
 	errMsg := fmt.Sprintf("Failed to update the DB Audit Logging configuration on cluster %s", clusterName)
 
+	integrationData, err := GetIntegrationDataByName(ctx, apiClient, accountId, projectId, plan.IntegrationName.Value)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to fetch integration details", err.Error())
+		return
+	}
+	plan.IntegrationId.Value = integrationData.GetInfo().Id
+
 	dbAuditLoggingConfigSpec, err := getDbAuditLoggingConfigSpec(plan)
 	if err != nil {
 		resp.Diagnostics.AddError(errMsg, err.Error())


### PR DESCRIPTION
When updating the DB audit logging resource, the integration data was not being fetched correctly. As a result, the value was null in the request payload, leading to an error during the update process.
This PR addresses the issue by ensuring that the appropriate integration data is fetched