### PR TITLE
[CLOUDGA-25821] Stop API key creation if wrong unit provided

### DIFF
--- a/managed/resource_api_key.go
+++ b/managed/resource_api_key.go
@@ -194,8 +194,9 @@ func (r resourceApiKey) Create(ctx context.Context, req tfsdk.CreateResourceRequ
 	if !validTimeUnit {
 		resp.Diagnostics.AddError(
 			"Invalid time unit for API Key creation",
-			"Available options are Hours, Days, and Months.",
+			"Available options are: Hours, Days, and Months.",
 		)
+		return
 	}
 
 	roleName := plan.RoleName.Value


### PR DESCRIPTION
Fixes: CLOUDGA-25821
Return as soon as we discover wrong unit is provided for API key duration.