### PR TITLE
Add plan modifiers to stop showing values that didn't change on TF plan

### DIFF
--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -43,16 +43,25 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 			Description: "The ID of the account this cluster belongs to.",
 			Type:        types.StringType,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"project_id": {
 			Description: "The ID of the project this cluster belongs to.",
 			Type:        types.StringType,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"cluster_id": {
 			Description: "The ID of the cluster. Created automatically when a cluster is created. Used to get a specific cluster.",
 			Type:        types.StringType,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"cluster_name": {
 			Description: "The name of the cluster.",
@@ -72,7 +81,10 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("AWS", "GCP", "AZURE")},
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
+			Validators: []tfsdk.AttributeValidator{stringvalidator.OneOf("AWS", "GCP", "AZURE")},
 		},
 		"cluster_region_info": {
 			Required: true,
@@ -90,6 +102,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.Int64Type,
 					Optional:    true,
 					Computed:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 					Validators: []tfsdk.AttributeValidator{
 						schemavalidator.ExactlyOneOf(
 							path.MatchRelative().AtParent().AtParent().AtParent().AtName("node_config").AtName("num_cores"),
@@ -102,6 +117,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.Int64Type,
 					Optional:    true,
 					Computed:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 					Validators: []tfsdk.AttributeValidator{
 						schemavalidator.ConflictsWith(
 							path.MatchRelative().AtParent().AtParent().AtParent().AtName("node_config").AtName("disk_size_gb"),
@@ -113,6 +131,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.Int64Type,
 					Optional:    true,
 					Computed:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 					Validators: []tfsdk.AttributeValidator{
 						schemavalidator.ConflictsWith(
 							path.MatchRelative().AtParent().AtParent().AtParent().AtName("node_config").AtName("disk_iops"),
@@ -123,6 +144,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:     types.StringType,
 					Optional: true,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 					Validators: []tfsdk.AttributeValidator{
 						schemavalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("vpc_name")),
 					},
@@ -131,34 +155,47 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:     types.StringType,
 					Optional: true,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"public_access": {
 					Type:     types.BoolType,
 					Optional: true,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"is_preferred": {
 					Type:     types.BoolType,
 					Optional: true,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"is_default": {
 					Type:     types.BoolType,
 					Optional: true,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 			}),
 		},
 		"backup_schedules": {
 			Optional: true,
 			Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-
 				"state": {
-
 					Description: "The state of the backup schedule. Used to pause or resume the backup schedule. Valid values are ACTIVE or PAUSED.",
 					Type:        types.StringType,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 
 				"cron_expression": {
@@ -166,6 +203,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.StringType,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 
 				"time_interval_in_days": {
@@ -173,6 +213,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.Int64Type,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 
 				"retention_period_in_days": {
@@ -180,6 +223,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.Int64Type,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 
 				"backup_description": {
@@ -187,6 +233,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.StringType,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 
 				"schedule_id": {
@@ -194,6 +243,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.StringType,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"incremental_interval_in_mins": {
 					Description: "The time interval in minutes for the incremental backup schedule.",
@@ -370,14 +422,20 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("NONE", "NODE", "ZONE", "REGION")},
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
+			Validators: []tfsdk.AttributeValidator{stringvalidator.OneOf("NONE", "NODE", "ZONE", "REGION")},
 		},
 		"num_faults_to_tolerate": {
 			Description: "The number of domain faults the cluster can tolerate. 0 for NONE, 1 for ZONE and [1-3] for NODE and REGION",
 			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
-			Validators:  []tfsdk.AttributeValidator{int64validator.OneOf(0, 1, 2, 3)},
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
+			Validators: []tfsdk.AttributeValidator{int64validator.OneOf(0, 1, 2, 3)},
 		},
 		"cluster_allow_list_ids": {
 			Description: "List of IDs of the allow lists assigned to the cluster.",
@@ -394,18 +452,27 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 		"node_config": {
 			Optional: true,
 			Computed: true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 			Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 				"num_cores": {
 					Description: "Number of CPU cores in the node.",
 					Type:        types.Int64Type,
 					Optional:    true,
 					Computed:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"disk_size_gb": {
 					Description: "Disk size of the node.",
 					Type:        types.Int64Type,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 					Validators: []tfsdk.AttributeValidator{
 						schemavalidator.ConflictsWith(
 							path.MatchRelative().AtParent().AtParent().AtName("cluster_region_info").AtAnyListIndex().AtName("disk_size_gb"),
@@ -417,6 +484,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:        types.Int64Type,
 					Computed:    true,
 					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 					Validators: []tfsdk.AttributeValidator{
 						schemavalidator.ConflictsWith(
 							path.MatchRelative().AtParent().AtParent().AtName("cluster_region_info").AtAnyListIndex().AtName("disk_iops"),
@@ -469,40 +539,64 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 		},
 		"cluster_info": {
 			Computed: true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 			Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 				"state": {
 					Type:     types.StringType,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"software_version": {
 					Type:     types.StringType,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"created_time": {
 					Type:     types.StringType,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 				"updated_time": {
 					Type:     types.StringType,
 					Computed: true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
 				},
 			}),
 		},
 		"cluster_version": {
 			Type:     types.StringType,
 			Computed: true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"database_track": {
 			Description: "The track of the database. Production or Innovation or Preview.",
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"desired_state": {
 			Description: "The desired state of the cluster, Active or Paused. This parameter can be used to pause/resume a cluster.",
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 			Validators: []tfsdk.AttributeValidator{
 				// Validate string value must be "Active" or "Paused"
 				stringvalidator.OneOfCaseInsensitive([]string{"Active", "Paused"}...),
@@ -513,6 +607,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 			Validators: []tfsdk.AttributeValidator{
 				// Validate string value must be "Enabled" or "Disabled"
 				stringvalidator.OneOfCaseInsensitive([]string{"Enabled", "Disabled"}...),
@@ -525,6 +622,9 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				ElemType: types.StringType,
 			},
 			Computed: true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"endpoints": {
 			Description: "The endpoints used to connect to the cluster.",
@@ -533,27 +633,42 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Description: "The accessibility type of the endpoint. PUBLIC or PRIVATE.",
 					Type:        types.StringType,
 					Computed:    true,
-					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
+					Optional: true,
 				},
 				"host": {
 					Description: "The host of the endpoint.",
 					Type:        types.StringType,
 					Computed:    true,
-					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
+					Optional: true,
 				},
 				"region": {
 					Description: "The region of the endpoint.",
 					Type:        types.StringType,
 					Computed:    true,
-					Optional:    true,
+					PlanModifiers: []tfsdk.AttributePlanModifier{
+						tfsdk.UseStateForUnknown(),
+					},
+					Optional: true,
 				},
 			}),
 			Computed: true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 		"cluster_certificate": {
 			Description: "The certificate used to connect to the cluster.",
 			Type:        types.StringType,
 			Computed:    true,
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.UseStateForUnknown(),
+			},
 		},
 	}
 	// Remove once feature flag is enabled


### PR DESCRIPTION
Today, when we run `terraform plan` we show all the computed attributed though they didn't change. It makes it difficult to properly identify the attributes that didn't change. Plan modifiers come to our rescue here helping us hide the computed attributes from the plan.

For example, here is the plan after changing `num_cores` before the change was done:
```
bash-5.2$ terraform plan
ybm_allow_list.mylist: Refreshing state...
ybm_cluster.single_region: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # ybm_cluster.single_region will be updated in-place
  ~ resource "ybm_cluster" "single_region" {
      ~ account_id             = "5379da8e-9248-42f4-bd25-ebd7341eae69" -> (known after apply)
      ~ backup_schedules       = [
          ~ {
              ~ backup_description       = "Default backup schedule" -> (known after apply)
              + cron_expression          = (known after apply)
              ~ schedule_id              = "d97a8d18-2d59-48f6-a7f7-5d9620ce9541" -> (known after apply)
                # (3 unchanged attributes hidden)
            },
        ]
      ~ cluster_certificate    = <<-EOT
            -----BEGIN CERTIFICATE-----
            redacted
            ------------------------------
        EOT -> (known after apply)
      ~ cluster_endpoints      = {
          - "us-west2" = "us-west2.dae29dd9-14e7-42fd-9da9-df98a1f21b62.gcp.devcloud.yugabyte.com"
        } -> (known after apply)
      ~ cluster_id             = "dae29dd9-14e7-42fd-9da9-df98a1f21b62" -> (known after apply)
      ~ cluster_info           = {
          ~ created_time     = "2025-01-29T21:36:45.425Z" -> (known after apply)
          ~ software_version = "2024.1.4.0-b108" -> (known after apply)
          ~ state            = "ACTIVE" -> (known after apply)
          ~ updated_time     = "2025-01-29T21:46:42.364Z" -> (known after apply)
        } -> (known after apply)
      ~ cluster_region_info    = [
          ~ {
              ~ disk_iops     = 0 -> (known after apply)
              ~ disk_size_gb  = 100 -> (known after apply)
              ~ is_default    = true -> (known after apply)
              ~ is_preferred  = false -> (known after apply)
              ~ num_cores     = 2 -> 4
              ~ public_access = true -> (known after apply)
              + vpc_id        = (known after apply)
              + vpc_name      = (known after apply)
                # (2 unchanged attributes hidden)
            },
        ]
      ~ cluster_version        = "8" -> (known after apply)
      ~ database_track         = "Innovation" -> (known after apply)
      ~ desired_state          = "Active" -> (known after apply)
      ~ endpoints              = [
          - {
              - accessibility_type = "PUBLIC" -> null
              - host               = "us-west2.dae29dd9-14e7-42fd-9da9-df98a1f21b62.gcp.devcloud.yugabyte.com" -> null
              - region             = "us-west2" -> null
            },
        ] -> (known after apply)
      ~ node_config            = {
          ~ disk_iops    = 0 -> (known after apply)
          ~ disk_size_gb = 100 -> (known after apply)
          ~ num_cores    = 2 -> (known after apply)
        } -> (known after apply)
      ~ num_faults_to_tolerate = 0 -> (known after apply)
      ~ project_id             = "847ad1d5-2eaa-46f5-8528-cca023d1f540" -> (known after apply)
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Here is it after the change is done:
```
bash-5.2$ terraform plan
ybm_allow_list.mylist: Refreshing state...
ybm_cluster.single_region: Refreshing state...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # ybm_cluster.single_region will be updated in-place
  ~ resource "ybm_cluster" "single_region" {
      ~ cluster_region_info    = [
          ~ {
              ~ num_cores     = 2 -> 4
                # (9 unchanged attributes hidden)
            },
        ]
        # (20 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
