### PR TITLE
[CLOUDGA-26188] Use new API's get instance-types, cloud-regions & node configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250204064923-ec656335987b
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250214102343-e1cac1f85673
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250204064923-ec656335987b h1:yvhcGfFhG06y3I6KOJBogTkCwZasKZiroRjpVbXYa1s=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250204064923-ec656335987b/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250214102343-e1cac1f85673 h1:3Sdk6lY7RUdpt6w8ukqXrr0CUceWIVnpm7jbFV2hMT8=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250214102343-e1cac1f85673/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/common.go
+++ b/managed/common.go
@@ -37,7 +37,7 @@ func getProjectId(ctx context.Context, apiClient *openapiclient.APIClient, accou
 }
 
 func getMemoryFromInstanceType(ctx context.Context, apiClient *openapiclient.APIClient, accountId string, cloud string, tier string, region string, numCores int32) (memory int32, memoryOK bool, errorMessage string) {
-	instanceResp, resp, err := apiClient.ClusterApi.GetSupportedNodeConfigurations(context.Background()).AccountId(accountId).Cloud(cloud).Tier(tier).Regions([]string{region}).Execute()
+	instanceResp, resp, err := apiClient.ClusterApi.GetSupportedNodeConfigurationsByAccount(context.Background(), accountId).Cloud(cloud).Tier(tier).Regions([]string{region}).Execute()
 	if err != nil {
 		errMsg := getErrorMessage(resp, err)
 		return 0, false, errMsg
@@ -61,7 +61,7 @@ func getMemoryFromInstanceType(ctx context.Context, apiClient *openapiclient.API
 }
 
 func getDiskSizeFromInstanceType(ctx context.Context, apiClient *openapiclient.APIClient, accountId string, cloud string, tier string, region string, numCores int32) (diskSize int32, diskSizeOK bool, errorMessage string) {
-	instanceResp, resp, err := apiClient.ClusterApi.GetSupportedNodeConfigurations(context.Background()).AccountId(accountId).Cloud(cloud).Tier(tier).Regions([]string{region}).Execute()
+	instanceResp, resp, err := apiClient.ClusterApi.GetSupportedNodeConfigurationsByAccount(context.Background(), accountId).Cloud(cloud).Tier(tier).Regions([]string{region}).Execute()
 	if err != nil {
 		errMsg := getErrorMessage(resp, err)
 		return 0, false, errMsg


### PR DESCRIPTION
### Test Plan:
Tested by trying to create a cluster(with incorrect fields intentionally) that calls the get supported nodes API.

```terraform
variable "password" {
  type        = string
  description = "YSQL and YCQL Password."
  sensitive   = true
}

# Single Region Cluster
resource "ybm_cluster" "single_region_cluster" {
  cluster_name = "single-region-cluster"
  cloud_type   = "GCP"
  cluster_type = "SYNCHRONOUS"
  cluster_region_info = [
    {
      region    = "us-west1"
      num_nodes = 1
    }
  ]
  cluster_tier           = "FREE"
  fault_tolerance        = "ZONE" # this value shd be none for free tier. Set to zone intentionally
  node_config = {
    num_cores    = 2
    disk_size_gb = 50
  }
  credentials = {
    username = "example_user"
    password = var.password
  }
}
```

And in proxy, I could see the call:
![image](https://github.com/user-attachments/assets/d63d6213-30ff-435f-99e0-6b21e984aac4)
