### PR TITLE
[CLOUDGA-27918] use get current account API instead of list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250214102343-e1cac1f85673
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250619182045-f840d6f3789f
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250214102343-e1cac1f85673 h1:3Sdk6lY7RUdpt6w8ukqXrr0CUceWIVnpm7jbFV2hMT8=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250214102343-e1cac1f85673/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250619182045-f840d6f3789f h1:88iCpHmK6MyzQrhUFlQ+WnAeVfKvOH+cDFO7jE/7bQk=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250619182045-f840d6f3789f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/common.go
+++ b/managed/common.go
@@ -19,12 +19,12 @@ import (
 var ErrFailedTask = errors.New("the task failed")
 
 func getProjectId(ctx context.Context, apiClient *openapiclient.APIClient, accountId string) (projectId string, projectIdOK bool, errorMessage string) {
-	accountResp, resp, err := apiClient.AccountApi.ListAccounts(ctx).Execute()
+	accountResp, resp, err := apiClient.AccountApi.GetCurrentAccount(ctx).Execute()
 	if err != nil {
 		errMsg := getErrorMessage(resp, err)
 		return "", false, errMsg
 	}
-	projectData := accountResp.GetData()[0].Info.GetProjects()
+	projectData := accountResp.Data.Info.GetProjects()
 	if len(projectData) == 0 {
 		return "", false, "The account is not associated with any projects."
 	}
@@ -116,7 +116,7 @@ func getTrackName(ctx context.Context, apiClient *openapiclient.APIClient, accou
 }
 
 func getAccountId(ctx context.Context, apiClient *openapiclient.APIClient) (accountId string, accountIdOK bool, errorMessage string) {
-	accountResp, resp, err := apiClient.AccountApi.ListAccounts(ctx).Execute()
+	accountResp, resp, err := apiClient.AccountApi.GetCurrentAccount(ctx).Execute()
 	if err != nil {
 		errMsg := getErrorMessage(resp, err)
 		if strings.Contains(err.Error(), "is not a valid") {
@@ -127,15 +127,7 @@ func getAccountId(ctx context.Context, apiClient *openapiclient.APIClient) (acco
 			return "", false, errMsg
 		}
 	}
-	accountData := accountResp.GetData()
-	if len(accountData) == 0 {
-		return "", false, "The user is not associated with any accounts."
-	}
-	if len(accountData) > 1 {
-		return "", false, "The user is associated with multiple accounts, please provide an account ID."
-	}
-	accountId = accountData[0].Info.Id
-	return accountId, true, ""
+	return accountResp.Data.Info.Id, true, ""
 }
 
 // Utils functions

--- a/managed/resource_allow_list_test.go
+++ b/managed/resource_allow_list_test.go
@@ -99,8 +99,8 @@ func TestCreateAllowList(t *testing.T) {
 	allowListDescription := "Allow connections from any IP address"
 	allowListID := "test-allow-list-id"
 	allowList := getMockAllowList(cfg, mockNetworkApi, mockProjectApi, mockAccountApi)
-	listAccountsRequest := getListAccountsRequest(ctx, cfg, mockAccountApi)
-	listAccountsResponse := getListAccountsResponse(accountID, projectID)
+	accountRequest := getCurrentAccountRequest(ctx, cfg, mockAccountApi)
+	accountResponse := getCurrentAccountResponse(accountID, projectID)
 
 	createAllowListRequest := getCreateAllowListRequest(ctx, cfg, accountID, projectID, mockNetworkApi)
 	createAllowListSpec := *openapiclient.NewNetworkAllowListSpec(allowListName, allowListDescription, cidrList)
@@ -156,8 +156,8 @@ func TestCreateAllowList(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
 
-			mockAccountApi.EXPECT().ListAccounts(ctx).Return(*listAccountsRequest).Times(2)
-			mockAccountApi.EXPECT().ListAccountsExecute(*listAccountsRequest).Return(*listAccountsResponse, httpSuccessResponse, nil).Times(2)
+			mockAccountApi.EXPECT().GetCurrentAccount(ctx).Return(*accountRequest).Times(2)
+			mockAccountApi.EXPECT().GetCurrentAccountExecute(*accountRequest).Return(*accountResponse, httpSuccessResponse, nil).Times(2)
 			mockNetworkApi.EXPECT().ListNetworkAllowLists(ctx, accountID, projectID).Return(*listNetworkAllowListsRequest).Times(1)
 			mockNetworkApi.EXPECT().ListNetworkAllowListsExecute(*listNetworkAllowListsRequest).Return(*listNetworkAllowListsResponse, httpSuccessResponse, nil).Times(1)
 			mockNetworkApi.EXPECT().CreateNetworkAllowList(ctx, accountID, projectID).Return(*createAllowListRequest).Times(1)
@@ -238,10 +238,10 @@ func TestReadAllowList(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
 
-			listProjectsRequest := getListAccountsRequest(ctx, cfg, mockAccountApi)
-			listProjectsResponse := getListAccountsResponse(accountID, "test-project-id")
-			mockAccountApi.EXPECT().ListAccounts(ctx).Return(*listProjectsRequest).Times(2)
-			mockAccountApi.EXPECT().ListAccountsExecute(*listProjectsRequest).Return(*listProjectsResponse, httpSuccessResponse, nil).Times(2)
+			accountRequest := getCurrentAccountRequest(ctx, cfg, mockAccountApi)
+			accountResponse := getCurrentAccountResponse(accountID, "test-project-id")
+			mockAccountApi.EXPECT().GetCurrentAccount(ctx).Return(*accountRequest).Times(2)
+			mockAccountApi.EXPECT().GetCurrentAccountExecute(*accountRequest).Return(*accountResponse, httpSuccessResponse, nil).Times(2)
 			mockNetworkApi.EXPECT().ListNetworkAllowLists(ctx, accountID, projectID).Return(*listNetworkAllowListsRequest).Times(1)
 			mockNetworkApi.EXPECT().ListNetworkAllowListsExecute(*listNetworkAllowListsRequest).Return(*listNetworkAllowListsResponseExist, httpSuccessResponse, nil).Times(1)
 			mockNetworkApi.EXPECT().GetNetworkAllowList(ctx, accountID, projectID, allowListID).Return(*getAllowListRequest).Times(1)

--- a/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
+++ b/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
@@ -66,6 +66,36 @@ func (mr *MockAccountApiMockRecorder) BatchInviteAccountUsersExecute(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchInviteAccountUsersExecute", reflect.TypeOf((*MockAccountApi)(nil).BatchInviteAccountUsersExecute), arg0)
 }
 
+// CreateNewAccount mocks base method.
+func (m *MockAccountApi) CreateNewAccount(arg0 context.Context, arg1 string) openapi.ApiCreateNewAccountRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNewAccount", arg0, arg1)
+	ret0, _ := ret[0].(openapi.ApiCreateNewAccountRequest)
+	return ret0
+}
+
+// CreateNewAccount indicates an expected call of CreateNewAccount.
+func (mr *MockAccountApiMockRecorder) CreateNewAccount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewAccount", reflect.TypeOf((*MockAccountApi)(nil).CreateNewAccount), arg0, arg1)
+}
+
+// CreateNewAccountExecute mocks base method.
+func (m *MockAccountApi) CreateNewAccountExecute(arg0 openapi.ApiCreateNewAccountRequest) (openapi.AccountResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNewAccountExecute", arg0)
+	ret0, _ := ret[0].(openapi.AccountResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateNewAccountExecute indicates an expected call of CreateNewAccountExecute.
+func (mr *MockAccountApiMockRecorder) CreateNewAccountExecute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewAccountExecute", reflect.TypeOf((*MockAccountApi)(nil).CreateNewAccountExecute), arg0)
+}
+
 // GetAccount mocks base method.
 func (m *MockAccountApi) GetAccount(arg0 context.Context, arg1 string) openapi.ApiGetAccountRequest {
 	m.ctrl.T.Helper()
@@ -81,10 +111,10 @@ func (mr *MockAccountApiMockRecorder) GetAccount(arg0, arg1 interface{}) *gomock
 }
 
 // GetAccountExecute mocks base method.
-func (m *MockAccountApi) GetAccountExecute(arg0 openapi.ApiGetAccountRequest) (openapi.AccountResponse, *http.Response, error) {
+func (m *MockAccountApi) GetAccountExecute(arg0 openapi.ApiGetAccountRequest) (openapi.DeprecatedAccountResponse, *http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountExecute", arg0)
-	ret0, _ := ret[0].(openapi.AccountResponse)
+	ret0, _ := ret[0].(openapi.DeprecatedAccountResponse)
 	ret1, _ := ret[1].(*http.Response)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -94,6 +124,36 @@ func (m *MockAccountApi) GetAccountExecute(arg0 openapi.ApiGetAccountRequest) (o
 func (mr *MockAccountApiMockRecorder) GetAccountExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountExecute", reflect.TypeOf((*MockAccountApi)(nil).GetAccountExecute), arg0)
+}
+
+// GetCurrentAccount mocks base method.
+func (m *MockAccountApi) GetCurrentAccount(arg0 context.Context) openapi.ApiGetCurrentAccountRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentAccount", arg0)
+	ret0, _ := ret[0].(openapi.ApiGetCurrentAccountRequest)
+	return ret0
+}
+
+// GetCurrentAccount indicates an expected call of GetCurrentAccount.
+func (mr *MockAccountApiMockRecorder) GetCurrentAccount(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentAccount", reflect.TypeOf((*MockAccountApi)(nil).GetCurrentAccount), arg0)
+}
+
+// GetCurrentAccountExecute mocks base method.
+func (m *MockAccountApi) GetCurrentAccountExecute(arg0 openapi.ApiGetCurrentAccountRequest) (openapi.AccountResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentAccountExecute", arg0)
+	ret0, _ := ret[0].(openapi.AccountResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetCurrentAccountExecute indicates an expected call of GetCurrentAccountExecute.
+func (mr *MockAccountApiMockRecorder) GetCurrentAccountExecute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentAccountExecute", reflect.TypeOf((*MockAccountApi)(nil).GetCurrentAccountExecute), arg0)
 }
 
 // GetAccountQuotas mocks base method.
@@ -291,10 +351,10 @@ func (mr *MockAccountApiMockRecorder) ListAccounts(arg0 interface{}) *gomock.Cal
 }
 
 // ListAccountsExecute mocks base method.
-func (m *MockAccountApi) ListAccountsExecute(arg0 openapi.ApiListAccountsRequest) (openapi.AccountListResponse, *http.Response, error) {
+func (m *MockAccountApi) ListAccountsExecute(arg0 openapi.ApiListAccountsRequest) (openapi.DeprecatedAccountListResponse, *http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountsExecute", arg0)
-	ret0, _ := ret[0].(openapi.AccountListResponse)
+	ret0, _ := ret[0].(openapi.DeprecatedAccountListResponse)
 	ret1, _ := ret[1].(*http.Response)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/mock_yugabytedb_managed_go_client_internal/mock_api_project.go
+++ b/mock_yugabytedb_managed_go_client_internal/mock_api_project.go
@@ -36,65 +36,6 @@ func (m *MockProjectApi) EXPECT() *MockProjectApiMockRecorder {
 	return m.recorder
 }
 
-// CreateProject mocks base method.
-func (m *MockProjectApi) CreateProject(arg0 context.Context, arg1 string) openapi.ApiCreateProjectRequest {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProject", arg0, arg1)
-	ret0, _ := ret[0].(openapi.ApiCreateProjectRequest)
-	return ret0
-}
-
-// CreateProject indicates an expected call of CreateProject.
-func (mr *MockProjectApiMockRecorder) CreateProject(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockProjectApi)(nil).CreateProject), arg0, arg1)
-}
-
-// CreateProjectExecute mocks base method.
-func (m *MockProjectApi) CreateProjectExecute(arg0 openapi.ApiCreateProjectRequest) (openapi.ProjectResponse, *http.Response, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProjectExecute", arg0)
-	ret0, _ := ret[0].(openapi.ProjectResponse)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CreateProjectExecute indicates an expected call of CreateProjectExecute.
-func (mr *MockProjectApiMockRecorder) CreateProjectExecute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProjectExecute", reflect.TypeOf((*MockProjectApi)(nil).CreateProjectExecute), arg0)
-}
-
-// DeleteProject mocks base method.
-func (m *MockProjectApi) DeleteProject(arg0 context.Context, arg1, arg2 string) openapi.ApiDeleteProjectRequest {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteProject", arg0, arg1, arg2)
-	ret0, _ := ret[0].(openapi.ApiDeleteProjectRequest)
-	return ret0
-}
-
-// DeleteProject indicates an expected call of DeleteProject.
-func (mr *MockProjectApiMockRecorder) DeleteProject(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockProjectApi)(nil).DeleteProject), arg0, arg1, arg2)
-}
-
-// DeleteProjectExecute mocks base method.
-func (m *MockProjectApi) DeleteProjectExecute(arg0 openapi.ApiDeleteProjectRequest) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteProjectExecute", arg0)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteProjectExecute indicates an expected call of DeleteProjectExecute.
-func (mr *MockProjectApiMockRecorder) DeleteProjectExecute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProjectExecute", reflect.TypeOf((*MockProjectApi)(nil).DeleteProjectExecute), arg0)
-}
-
 // GetProject mocks base method.
 func (m *MockProjectApi) GetProject(arg0 context.Context, arg1, arg2 string) openapi.ApiGetProjectRequest {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Summary

- [CLOUDGA-27918] use get current account API instead of list

### Test Plan

Tested by creating an API key via Terraform.
```shell
~/code/terraform-provider-ybm on CLOUDGA-27918 *1 ?2                                                                                          took 4s py base at 17:57:08
> make install
go build -ldflags="-X 'main.version=v0.1.0-dev'" -o terraform-provider-ybm
mkdir -p ~/.terraform.d/plugins/registry.terraform.io/yugabyte/ybm/0.1.0-dev/darwin_arm64/
mv terraform-provider-ybm ~/.terraform.d/plugins/registry.terraform.io/yugabyte/ybm/0.1.0-dev/darwin_arm64/

~/code/tf-local-testing                                                                                                                    py base az ybm-sre at 18:25:17
> tfa -auto-approve -var auth_token=$(cat dev-ak)

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ybm_api_key.example_api_key will be created
  + resource "ybm_api_key" "example_api_key" {
      + account_id   = (known after apply)
      + api_key      = (sensitive value)
      + api_key_id   = (known after apply)
      + date_created = (known after apply)
      + description  = "example API Key description"
      + duration     = 10
      + expiration   = (known after apply)
      + issuer       = (known after apply)
      + last_used    = (known after apply)
      + name         = "errored-api2"
      + project_id   = (known after apply)
      + role_name    = "Developer"
      + status       = (known after apply)
      + unit         = "Hours"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
ybm_api_key.example_api_key: Creating...
ybm_api_key.example_api_key: Creation complete after 2s [name=errored-api2]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

~/code/tf-local-testing                                                                                                            took 3s py base az ybm-sre at 18:25:32
> tfa -auto-approve -var auth_token=$(cat dev-ak)
ybm_api_key.example_api_key: Refreshing state... [name=errored-api2]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # ybm_api_key.example_api_key will be destroyed
  # (because ybm_api_key.example_api_key is not in configuration)
  - resource "ybm_api_key" "example_api_key" {
      - account_id   = "cad5c492-f477-42e8-b597-e74376fa2257" -> null
      - api_key      = (sensitive value) -> null
      - api_key_id   = "086f7851-4e37-4944-9c35-523e21a28f45" -> null
      - date_created = "2025-06-25T12:55:31.752Z" -> null
      - description  = "example API Key description" -> null
      - duration     = 10 -> null
      - expiration   = "2025-06-25T22:55:31.752031Z" -> null
      - issuer       = "admin" -> null
      - last_used    = "Not yet used" -> null
      - name         = "errored-api2" -> null
      - project_id   = "9fdb6067-af71-4546-8536-59aa676e1175" -> null
      - role_name    = "Developer" -> null
      - status       = "ACTIVE" -> null
      - unit         = "Hours" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
ybm_api_key.example_api_key: Destroying... [name=errored-api2]
ybm_api_key.example_api_key: Destruction complete after 1s

Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
```

### Sample TF:

```shell
terraform {
  required_providers {
    ybm = {
      #version = "1.0.25"
      source  = "registry.terraform.io/yugabyte/ybm"
      version = "0.1.0-dev"
      # source = "local/ybm"
    }
  }
}

provider "ybm" {
  host            = "devcloud.yugabyte.com"
  # use_secure_host = true
  # host            = "localhost:5678"
  use_secure_host = false
  auth_token      = var.auth_token
}

variable "auth_token" {
  type        = string
  description = "The authentication token."
  sensitive   = true
}

resource "ybm_api_key" "example_api_key" {
  name        = "errored-api"
  description = "example API Key description" #Optional
  duration    = 10
  unit        = "Hours"
  role_name   = "Developer"
}
```