### PR TITLE
[CLOUDGA-28235] Update edit cluster schema and operation to allow backup replication related modifications

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -44,6 +44,7 @@ data "ybm_cluster" "example_cluster" {
 - `cmk_spec` (Attributes) KMS Provider Configuration. (see [below for nested schema](#nestedatt--cmk_spec))
 - `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
 - `database_track` (String) The track of the database. Stable or Preview.
+- `desired_connection_pooling_state` (String) The desired connection pooling state of the cluster, Enabled or Disabled.
 - `desired_state` (String) The desired state of the database, Active or Paused. This parameter can be used to pause/resume a cluster.
 - `endpoints` (Attributes List) The endpoints used to connect to the cluster. (see [below for nested schema](#nestedatt--endpoints))
 - `fault_tolerance` (String) The fault tolerance of the cluster.
@@ -82,8 +83,12 @@ Read-Only:
 
 Read-Only:
 
+- `backup_region` (Boolean) Indicates whether cluster backup data will be stored in this region.
+- `backup_replication_gcp_target` (String) GCS bucket name set as backup replication target.
 - `disk_iops` (Number)
 - `disk_size_gb` (Number)
+- `is_default` (Boolean)
+- `is_preferred` (Boolean)
 - `num_cores` (Number)
 - `num_nodes` (Number)
 - `public_access` (Boolean)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -595,6 +595,233 @@ resource "ybm_private_service_endpoint" "npsenonok-region" {
 }
 ```
 
+To edit a GCP Cluster with backup replication
+
+```terraform
+variable "password" {
+  type        = string
+  description = "YSQL and YCQL Password."
+  sensitive   = true
+}
+
+# Comprehensive Backup Replication Examples
+# This file demonstrates different backup replication strategies for various cluster types
+
+# 1. Single Region Cluster with Backup Replication
+resource "ybm_cluster" "single_region_backup_replication" {
+  cluster_name = "single-region-backup-replication"
+  cloud_type   = "GCP"
+  cluster_type = "SYNCHRONOUS"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id"
+      public_access                 = true
+      backup_replication_gcp_target = "single-region-backup-bucket"
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "NONE"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# 2. Multi-Region SYNCHRONOUS Cluster with Centralized Backup
+# All regions backup to the same GCS bucket
+resource "ybm_cluster" "multi_region_sync_centralized_backup" {
+  cluster_name = "multi-region-sync-centralized-backup"
+  cloud_type   = "GCP"
+  cluster_type = "SYNCHRONOUS"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-1"
+      public_access                 = true
+      backup_replication_gcp_target = "central-backup-bucket" # Same for all regions
+    },
+    {
+      region                        = "us-central1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-2"
+      public_access                 = true
+      backup_replication_gcp_target = "central-backup-bucket" # Same for all regions
+    },
+    {
+      region                        = "us-east1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-3"
+      public_access                 = true
+      backup_replication_gcp_target = "central-backup-bucket" # Same for all regions
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "REGION"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# 3. Multi-Region GEO_PARTITIONED Cluster with Region-Specific Backup
+# Each region can have different backup targets for compliance or performance reasons
+resource "ybm_cluster" "multi_region_geo_region_specific_backup" {
+  cluster_name = "multi-region-geo-region-specific-backup"
+  cloud_type   = "GCP"
+  cluster_type = "GEO_PARTITIONED"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-1"
+      public_access                 = true
+      backup_replication_gcp_target = "us-west-backup-bucket" # Region-specific
+    },
+    {
+      region                        = "asia-east1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-2"
+      public_access                 = true
+      backup_replication_gcp_target = "asia-east-backup-bucket" # Region-specific
+    },
+    {
+      region                        = "europe-central2"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-3"
+      public_access                 = true
+      backup_replication_gcp_target = "europe-central-backup-bucket" # Region-specific
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "REGION"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# 4. Asymmetric GEO_PARTITIONED Cluster with Mixed Backup Strategy
+# Some regions share backup targets, others have unique targets
+resource "ybm_cluster" "asymmetric_geo_mixed_backup" {
+  cluster_name = "asymmetric-geo-mixed-backup"
+  cloud_type   = "GCP"
+  cluster_type = "GEO_PARTITIONED"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-1"
+      public_access                 = true
+      backup_replication_gcp_target = "us-west-backup-bucket"
+    },
+    {
+      region                        = "us-central1"
+      num_nodes                     = 1
+      num_cores                     = 4
+      disk_size_gb                  = 100
+      vpc_id                        = "example-vpc-id-2"
+      public_access                 = true
+      backup_replication_gcp_target = "us-central-backup-bucket"
+    },
+    {
+      region                        = "us-east1"
+      num_nodes                     = 1
+      num_cores                     = 4
+      disk_size_gb                  = 100
+      vpc_id                        = "example-vpc-id-3"
+      public_access                 = true
+      backup_replication_gcp_target = "us-central-backup-bucket" # Same as us-central1
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "REGION"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# Important Notes:
+# 
+# 1. backup_replication_gcp_target can ONLY be set when editing existing clusters
+#    - It will be ignored during initial cluster creation
+#    - To add backup replication, first create the cluster, then update the configuration
+#
+# 2. Cluster Type Rules:
+#    - SYNCHRONOUS: All regions MUST have the same backup_replication_gcp_target
+#    - GEO_PARTITIONED: Each region can have different backup_replication_gcp_target values. This allows for region-specific backup strategies and compliance requirements
+#
+# 3. Requirements:
+#    - Only supported for GCP clusters
+#    - Only supported for PAID tier clusters
+#    - All regions must have backup_replication_gcp_target if any are provided
+#
+# 4. Use Cases:
+#    - Centralized backup strategy (SYNCHRONOUS clusters)
+#    - Region-specific compliance requirements (GEO_PARTITIONED clusters)
+#    - Performance optimization by keeping backups close to data
+#    - Disaster recovery planning with multiple backup locations
+```
+
 
 <!-- schema generated by tfplugindocs -->
 ## Schema
@@ -643,6 +870,7 @@ Required:
 
 Optional:
 
+- `backup_replication_gcp_target` (String) GCS bucket name for backup replication target. Only configurable when editing existing clusters. For SYNCHRONOUS clusters, all regions must have the same target. For GEO_PARTITIONED clusters, each region can have different targets. Only supported for GCP clusters and PAID tier.
 - `disk_iops` (Number) Disk IOPS of the nodes of the region.
 - `disk_size_gb` (Number) Disk size of the nodes of the region.
 - `is_default` (Boolean)
@@ -651,6 +879,10 @@ Optional:
 - `public_access` (Boolean)
 - `vpc_id` (String)
 - `vpc_name` (String)
+
+Read-Only:
+
+- `backup_region` (Boolean) Indicates whether cluster backup data will be stored in this region.
 
 
 <a id="nestedatt--credentials"></a>

--- a/examples/resources/ybm_cluster/cluster-edit-backup-replication.tf
+++ b/examples/resources/ybm_cluster/cluster-edit-backup-replication.tf
@@ -1,0 +1,222 @@
+variable "password" {
+  type        = string
+  description = "YSQL and YCQL Password."
+  sensitive   = true
+}
+
+# Comprehensive Backup Replication Examples
+# This file demonstrates different backup replication strategies for various cluster types
+
+# 1. Single Region Cluster with Backup Replication
+resource "ybm_cluster" "single_region_backup_replication" {
+  cluster_name = "single-region-backup-replication"
+  cloud_type   = "GCP"
+  cluster_type = "SYNCHRONOUS"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id"
+      public_access                 = true
+      backup_replication_gcp_target = "single-region-backup-bucket"
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "NONE"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# 2. Multi-Region SYNCHRONOUS Cluster with Centralized Backup
+# All regions backup to the same GCS bucket
+resource "ybm_cluster" "multi_region_sync_centralized_backup" {
+  cluster_name = "multi-region-sync-centralized-backup"
+  cloud_type   = "GCP"
+  cluster_type = "SYNCHRONOUS"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-1"
+      public_access                 = true
+      backup_replication_gcp_target = "central-backup-bucket" # Same for all regions
+    },
+    {
+      region                        = "us-central1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-2"
+      public_access                 = true
+      backup_replication_gcp_target = "central-backup-bucket" # Same for all regions
+    },
+    {
+      region                        = "us-east1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-3"
+      public_access                 = true
+      backup_replication_gcp_target = "central-backup-bucket" # Same for all regions
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "REGION"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# 3. Multi-Region GEO_PARTITIONED Cluster with Region-Specific Backup
+# Each region can have different backup targets for compliance or performance reasons
+resource "ybm_cluster" "multi_region_geo_region_specific_backup" {
+  cluster_name = "multi-region-geo-region-specific-backup"
+  cloud_type   = "GCP"
+  cluster_type = "GEO_PARTITIONED"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-1"
+      public_access                 = true
+      backup_replication_gcp_target = "us-west-backup-bucket" # Region-specific
+    },
+    {
+      region                        = "asia-east1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-2"
+      public_access                 = true
+      backup_replication_gcp_target = "asia-east-backup-bucket" # Region-specific
+    },
+    {
+      region                        = "europe-central2"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-3"
+      public_access                 = true
+      backup_replication_gcp_target = "europe-central-backup-bucket" # Region-specific
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "REGION"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# 4. Asymmetric GEO_PARTITIONED Cluster with Mixed Backup Strategy
+# Some regions share backup targets, others have unique targets
+resource "ybm_cluster" "asymmetric_geo_mixed_backup" {
+  cluster_name = "asymmetric-geo-mixed-backup"
+  cloud_type   = "GCP"
+  cluster_type = "GEO_PARTITIONED"
+  cluster_region_info = [
+    {
+      region                        = "us-west1"
+      num_nodes                     = 1
+      num_cores                     = 2
+      disk_size_gb                  = 50
+      vpc_id                        = "example-vpc-id-1"
+      public_access                 = true
+      backup_replication_gcp_target = "us-west-backup-bucket"
+    },
+    {
+      region                        = "us-central1"
+      num_nodes                     = 1
+      num_cores                     = 4
+      disk_size_gb                  = 100
+      vpc_id                        = "example-vpc-id-2"
+      public_access                 = true
+      backup_replication_gcp_target = "us-central-backup-bucket"
+    },
+    {
+      region                        = "us-east1"
+      num_nodes                     = 1
+      num_cores                     = 4
+      disk_size_gb                  = 100
+      vpc_id                        = "example-vpc-id-3"
+      public_access                 = true
+      backup_replication_gcp_target = "us-central-backup-bucket" # Same as us-central1
+    }
+  ]
+  cluster_tier           = "PAID"
+  cluster_allow_list_ids = ["example-allow-list-id"]
+  fault_tolerance        = "REGION"
+
+  backup_schedules = [
+    {
+      state                    = "ACTIVE"
+      retention_period_in_days = 30
+      time_interval_in_days    = 7
+    }
+  ]
+
+  credentials = {
+    username = "example_user"
+    password = var.password
+  }
+}
+
+# Important Notes:
+# 
+# 1. backup_replication_gcp_target can ONLY be set when editing existing clusters
+#    - It will be ignored during initial cluster creation
+#    - To add backup replication, first create the cluster, then update the configuration
+#
+# 2. Cluster Type Rules:
+#    - SYNCHRONOUS: All regions MUST have the same backup_replication_gcp_target
+#    - GEO_PARTITIONED: Each region can have different backup_replication_gcp_target values. This allows for region-specific backup strategies and compliance requirements
+#
+# 3. Requirements:
+#    - Only supported for GCP clusters
+#    - Only supported for PAID tier clusters
+#    - All regions must have backup_replication_gcp_target if any are provided
+#
+# 4. Use Cases:
+#    - Centralized backup strategy (SYNCHRONOUS clusters)
+#    - Region-specific compliance requirements (GEO_PARTITIONED clusters)
+#    - Performance optimization by keeping backups close to data
+#    - Disaster recovery planning with multiple backup locations

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250619182045-f840d6f3789f
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250818090100-de6585242c8e
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,10 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250619182045-f840d6f3789f h1:88iCpHmK6MyzQrhUFlQ+WnAeVfKvOH+cDFO7jE/7bQk=
 github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250619182045-f840d6f3789f/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250812110131-0f0c5535966e h1:9hazXAROAR9wa1/0SyhxFkWtmtqAz5bzQNboNqek5UY=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250812110131-0f0c5535966e/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250818090100-de6585242c8e h1:DAwXWlzWoG8iqdzm1QuKP4+yJki4A3ML1qC9CoK7Maw=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250818090100-de6585242c8e/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -88,6 +88,14 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 						Type:     types.BoolType,
 						Computed: true,
 					},
+					"is_preferred": {
+						Type:     types.BoolType,
+						Computed: true,
+					},
+					"is_default": {
+						Type:     types.BoolType,
+						Computed: true,
+					},
 					"backup_replication_gcp_target": {
 						Description: "GCS bucket name for backup replication target. Only configurable when editing existing clusters. For SYNCHRONOUS clusters, all regions must have the same target. For GEO_PARTITIONED clusters, each region can have different targets. Only supported for GCP clusters and PAID tier.",
 						Type:        types.StringType,
@@ -407,6 +415,11 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				Type:        types.StringType,
 				Computed:    true,
 			},
+			"desired_connection_pooling_state": {
+				Description: "The desired connection pooling state of the cluster, Enabled or Disabled. This parameter can be used to enable/disable Connection Pooling",
+				Type:        types.StringType,
+				Computed:    true,
+			},
 			"cluster_endpoints": {
 				Description: "The endpoints used to connect to the cluster by region.",
 				Type: types.MapType{
@@ -533,7 +546,7 @@ func (r dataClusterName) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 		return
 	}
 
-	diags := resp.State.Set(ctx, &cluster)
+	diags := setClusterState(ctx, &resp.State, &cluster)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -88,6 +88,11 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 						Type:     types.BoolType,
 						Computed: true,
 					},
+					"backup_replication_gcp_target": {
+						Description: "GCS bucket name for backup replication target. Only configurable when editing existing clusters. For SYNCHRONOUS clusters, all regions must have the same target. For GEO_PARTITIONED clusters, each region can have different targets. Only supported for GCP clusters and PAID tier.",
+						Type:        types.StringType,
+						Computed:    true,
+					},
 				}),
 			},
 			"backup_schedules": {

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -97,8 +97,13 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 						Computed: true,
 					},
 					"backup_replication_gcp_target": {
-						Description: "GCS bucket name for backup replication target. Only configurable when editing existing clusters. For SYNCHRONOUS clusters, all regions must have the same target. For GEO_PARTITIONED clusters, each region can have different targets. Only supported for GCP clusters and PAID tier.",
+						Description: "GCS bucket name set as backup replication target.",
 						Type:        types.StringType,
+						Computed:    true,
+					},
+					"backup_region": {
+						Description: "Indicates whether cluster backup data will be stored in this region.",
+						Type:        types.BoolType,
 						Computed:    true,
 					},
 				}),

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -421,7 +421,7 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				Computed:    true,
 			},
 			"desired_connection_pooling_state": {
-				Description: "The desired connection pooling state of the cluster, Enabled or Disabled. This parameter can be used to enable/disable Connection Pooling",
+				Description: "The desired connection pooling state of the cluster, Enabled or Disabled.",
 				Type:        types.StringType,
 				Computed:    true,
 			},

--- a/managed/fflags/feature_flags.go
+++ b/managed/fflags/feature_flags.go
@@ -18,7 +18,7 @@ const (
 )
 
 var flagEnabled = map[FeatureFlag]bool{
-	CONNECTION_POOLING: false,
+	CONNECTION_POOLING: true,
 	DR:                 false,
 }
 

--- a/managed/fflags/feature_flags.go
+++ b/managed/fflags/feature_flags.go
@@ -18,7 +18,7 @@ const (
 )
 
 var flagEnabled = map[FeatureFlag]bool{
-	CONNECTION_POOLING: true,
+	CONNECTION_POOLING: false,
 	DR:                 false,
 }
 

--- a/managed/models.go
+++ b/managed/models.go
@@ -106,6 +106,7 @@ type RegionInfo struct {
 	IsPreferred                types.Bool   `tfsdk:"is_preferred"`
 	IsDefault                  types.Bool   `tfsdk:"is_default"`
 	BackupReplicationGCPTarget types.String `tfsdk:"backup_replication_gcp_target"`
+	BackupRegion               types.Bool   `tfsdk:"backup_region"`
 }
 
 type NodeConfig struct {

--- a/managed/models.go
+++ b/managed/models.go
@@ -95,16 +95,17 @@ type BackupScheduleInfo struct {
 	IncrementalIntervalInMins types.Int64  `tfsdk:"incremental_interval_in_mins"`
 }
 type RegionInfo struct {
-	Region       types.String `tfsdk:"region"`
-	NumNodes     types.Int64  `tfsdk:"num_nodes"`
-	NumCores     types.Int64  `tfsdk:"num_cores"`
-	DiskSizeGb   types.Int64  `tfsdk:"disk_size_gb"`
-	DiskIops     types.Int64  `tfsdk:"disk_iops"`
-	VPCID        types.String `tfsdk:"vpc_id"`
-	VPCName      types.String `tfsdk:"vpc_name"`
-	PublicAccess types.Bool   `tfsdk:"public_access"`
-	IsPreferred  types.Bool   `tfsdk:"is_preferred"`
-	IsDefault    types.Bool   `tfsdk:"is_default"`
+	Region                     types.String `tfsdk:"region"`
+	NumNodes                   types.Int64  `tfsdk:"num_nodes"`
+	NumCores                   types.Int64  `tfsdk:"num_cores"`
+	DiskSizeGb                 types.Int64  `tfsdk:"disk_size_gb"`
+	DiskIops                   types.Int64  `tfsdk:"disk_iops"`
+	VPCID                      types.String `tfsdk:"vpc_id"`
+	VPCName                    types.String `tfsdk:"vpc_name"`
+	PublicAccess               types.Bool   `tfsdk:"public_access"`
+	IsPreferred                types.Bool   `tfsdk:"is_preferred"`
+	IsDefault                  types.Bool   `tfsdk:"is_default"`
+	BackupReplicationGCPTarget types.String `tfsdk:"backup_replication_gcp_target"`
 }
 
 type NodeConfig struct {

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -2005,15 +2005,10 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 			tflog.Debug(ctx, fmt.Sprintf("For region %v, publicAccess = %v", region, publicAccess))
 
 			var backupReplicationGCPTarget types.String
-			tflog.Info(ctx, fmt.Sprintf("Siddarth printing repl target %v : %v , %v", cluster.ClusterName, info.GetBackupReplicationGcpTarget(), info.HasBackupReplicationGcpTarget()))
 			if info.HasBackupReplicationGcpTarget() && len(info.GetBackupReplicationGcpTarget()) > 0 {
-				tflog.Info(ctx, fmt.Sprintf("Siddarth Has target %v", cluster.ClusterName))
 				backupReplicationGCPTarget = types.String{Value: info.GetBackupReplicationGcpTarget()}
-				tflog.Info(ctx, fmt.Sprintf("Siddarth stored target %v", cluster.ClusterName))
 			} else {
-				tflog.Info(ctx, fmt.Sprintf("Siddarth no target %v", cluster.ClusterName))
 				backupReplicationGCPTarget = types.String{Null: true}
-				tflog.Info(ctx, fmt.Sprintf("Siddarth no target. Set null %v", cluster.ClusterName))
 			}
 
 			// Handle backup region - get from cluster_region_info_details

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -168,6 +169,18 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Computed: true,
 					PlanModifiers: []tfsdk.AttributePlanModifier{
 						tfsdk.UseStateForUnknown(),
+					},
+				},
+				"backup_replication_gcp_target": {
+					Description: "GCS bucket name for backup replication target. Only configurable when editing existing clusters. For SYNCHRONOUS clusters, all regions must have the same target. For GEO_PARTITIONED clusters, each region can have different targets. Only supported for GCP clusters and PAID tier.",
+					Type:        types.StringType,
+					Optional:    true,
+					Computed:    true,
+					Validators: []tfsdk.AttributeValidator{
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$`),
+							"GCS bucket names must contain only lowercase letters, numbers, hyphens, and underscores, and must start and end with a letter or number",
+						),
 					},
 				},
 			}),
@@ -816,6 +829,10 @@ func createClusterSpec(ctx context.Context, apiClient *openapiclient.APIClient, 
 			isDefaultSet = true
 		}
 
+		if !regionInfo.BackupReplicationGCPTarget.IsNull() && !regionInfo.BackupReplicationGCPTarget.IsUnknown() && regionInfo.BackupReplicationGCPTarget.Value != "" {
+			info.SetBackupReplicationGcpTarget(regionInfo.BackupReplicationGCPTarget.Value)
+		}
+
 		clusterRegionInfo = append(clusterRegionInfo, info)
 	}
 
@@ -1165,6 +1182,15 @@ func (r resourceCluster) Create(ctx context.Context, req tfsdk.CreateResourceReq
 				resp.Diagnostics.AddError("Invalid disk IOPS in "+regionInfo.Region.Value, err)
 				return
 			}
+		}
+
+		// Validate that backup replication targets are not provided during cluster creation
+		if !regionInfo.BackupReplicationGCPTarget.IsNull() && !regionInfo.BackupReplicationGCPTarget.IsUnknown() && regionInfo.BackupReplicationGCPTarget.Value != "" {
+			resp.Diagnostics.AddError(
+				"Backup replication targets not supported during cluster creation",
+				"Backup replication targets can only be configured when editing existing clusters. Please remove the backup_replication_gcp_target field and try again.",
+			)
+			return
 		}
 	}
 
@@ -1973,17 +1999,30 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 
 			tflog.Debug(ctx, fmt.Sprintf("For region %v, publicAccess = %v", region, publicAccess))
 
+			var backupReplicationGCPTarget types.String
+			tflog.Info(ctx, fmt.Sprintf("Siddarth printing repl target %v : %v , %v", cluster.ClusterName, info.GetBackupReplicationGcpTarget(), info.HasBackupReplicationGcpTarget()))
+			if info.HasBackupReplicationGcpTarget() && len(info.GetBackupReplicationGcpTarget()) > 0 {
+				tflog.Info(ctx, fmt.Sprintf("Siddarth Has target %v", cluster.ClusterName))
+				backupReplicationGCPTarget = types.String{Value: info.GetBackupReplicationGcpTarget()}
+				tflog.Info(ctx, fmt.Sprintf("Siddarth stored target %v", cluster.ClusterName))
+			} else {
+				tflog.Info(ctx, fmt.Sprintf("Siddarth no target %v", cluster.ClusterName))
+				backupReplicationGCPTarget = types.String{Null: true}
+				tflog.Info(ctx, fmt.Sprintf("Siddarth no target. Set null %v", cluster.ClusterName))
+			}
+
 			regionInfo := RegionInfo{
-				Region:       types.String{Value: region},
-				NumNodes:     types.Int64{Value: int64(info.PlacementInfo.GetNumNodes())},
-				NumCores:     types.Int64{Value: int64(info.NodeInfo.Get().GetNumCores())},
-				DiskSizeGb:   types.Int64{Value: int64(info.NodeInfo.Get().GetDiskSizeGb())},
-				DiskIops:     types.Int64{Value: int64(info.NodeInfo.Get().GetDiskIops())},
-				VPCID:        types.String{Value: vpcID},
-				VPCName:      types.String{Value: vpcName},
-				PublicAccess: types.Bool{Value: publicAccess},
-				IsPreferred:  types.Bool{Value: info.GetIsAffinitized()},
-				IsDefault:    types.Bool{Value: info.GetIsDefault()},
+				Region:                     types.String{Value: region},
+				NumNodes:                   types.Int64{Value: int64(info.PlacementInfo.GetNumNodes())},
+				NumCores:                   types.Int64{Value: int64(info.NodeInfo.Get().GetNumCores())},
+				DiskSizeGb:                 types.Int64{Value: int64(info.NodeInfo.Get().GetDiskSizeGb())},
+				DiskIops:                   types.Int64{Value: int64(info.NodeInfo.Get().GetDiskIops())},
+				VPCID:                      types.String{Value: vpcID},
+				VPCName:                    types.String{Value: vpcName},
+				PublicAccess:               types.Bool{Value: publicAccess},
+				IsPreferred:                types.Bool{Value: info.GetIsAffinitized()},
+				IsDefault:                  types.Bool{Value: info.GetIsDefault()},
+				BackupReplicationGCPTarget: backupReplicationGCPTarget,
 			}
 			clusterRegionInfo[destIndex] = regionInfo
 		}
@@ -2176,6 +2215,11 @@ func (r resourceCluster) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 				return
 			}
 		}
+	}
+
+	if err := validateBackupReplicationTargets(plan.ClusterType.Value, plan.ClusterTier.Value, plan.CloudType.Value, plan.ClusterRegionInfo); err != nil {
+		resp.Diagnostics.AddError("Invalid backup replication configuration", err.Error())
+		return
 	}
 
 	scheduleId := ""
@@ -2513,4 +2557,43 @@ func (r resourceCluster) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 func (r resourceCluster) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	// Save the import identifier in the id attribute
 	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func validateBackupReplicationTargets(clusterType string, clusterTier string, cloudType string, regionInfos []RegionInfo) error {
+	// Collect all non-empty backup replication targets
+	var regionGcpTargets []string
+	for _, regionInfo := range regionInfos {
+		if !regionInfo.BackupReplicationGCPTarget.IsNull() && !regionInfo.BackupReplicationGCPTarget.IsUnknown() && regionInfo.BackupReplicationGCPTarget.Value != "" {
+			regionGcpTargets = append(regionGcpTargets, regionInfo.BackupReplicationGCPTarget.Value)
+		}
+	}
+
+	if len(regionGcpTargets) == 0 {
+		return nil
+	}
+
+	if clusterTier == "FREE" {
+		return fmt.Errorf("backup replication is not supported for free tier clusters")
+	}
+
+	if cloudType != "GCP" {
+		return fmt.Errorf("backup replication to GCS buckets is only supported for GCP clusters")
+	}
+
+	if len(regionGcpTargets) != len(regionInfos) {
+		return fmt.Errorf("all regions must have backup replication targets")
+	}
+
+	// For SYNCHRONOUS clusters, all regions must have the same target
+	if clusterType == "SYNCHRONOUS" {
+		uniqueTargets := make(map[string]bool)
+		for _, target := range regionGcpTargets {
+			uniqueTargets[target] = true
+		}
+		if len(uniqueTargets) > 1 {
+			return fmt.Errorf("all regions must have the same backup replication targets for synchronous clusters")
+		}
+	}
+
+	return nil
 }

--- a/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
+++ b/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
@@ -187,10 +187,10 @@ func (mr *MockAccountApiMockRecorder) GetAccountQuotasExecute(arg0 interface{}) 
 }
 
 // GetAccountUser mocks base method.
-func (m *MockAccountApi) GetAccountUser(arg0 context.Context, arg1, arg2 string) openapi.ApiGetAccountUserRequest {
+func (m *MockAccountApi) GetAccountUser(arg0 context.Context, arg1, arg2 string) openapi.ApiGetUserRequest {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountUser", arg0, arg1, arg2)
-	ret0, _ := ret[0].(openapi.ApiGetAccountUserRequest)
+	ret0, _ := ret[0].(openapi.ApiGetUserRequest)
 	return ret0
 }
 
@@ -201,7 +201,7 @@ func (mr *MockAccountApiMockRecorder) GetAccountUser(arg0, arg1, arg2 interface{
 }
 
 // GetAccountUserExecute mocks base method.
-func (m *MockAccountApi) GetAccountUserExecute(arg0 openapi.ApiGetAccountUserRequest) (openapi.UserResponse, *http.Response, error) {
+func (m *MockAccountApi) GetAccountUserExecute(arg0 openapi.ApiGetUserRequest) (openapi.UserResponse, *http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountUserExecute", arg0)
 	ret0, _ := ret[0].(openapi.UserResponse)

--- a/templates/resources/cluster.md.tmpl
+++ b/templates/resources/cluster.md.tmpl
@@ -51,5 +51,9 @@ To create an Azure Cluster , VPC and service endpoint all together
 
 {{ tffile "examples/resources/ybm_cluster/single-region-azure-vpc-pse.tf" }}
 
+To edit a GCP Cluster with backup replication
+
+{{ tffile "examples/resources/ybm_cluster/cluster-edit-backup-replication.tf" }}
+
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
1. GCP Backup Replication Target Update via Edit Cluster
   - Users can now update the `backup_replication_gcp_target` for GCP clusters through the Edit workflow. This enables flexible backup strategies for both SYNCHRONOUS and GEO_PARTITIONED clusters, with validation for cluster type, tier, and cloud provider.

2. Cluster Data Source Schema Fixes
   - Added missing fields to the data source schema:
     - `desired_connection_pooling_state`
     - `is_preferred`
     - `is_default`
   - This resolves errors when fetching cluster data and ensures the Terraform state is populated correctly.

3. Backup Region Visibility
   - Introduced the `backup_region` field to cluster region info, making it easy to identify which regions are designated as backup regions.
