### PR TITLE
Fix error with read multi-region cluster

### DIFF
--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -1720,8 +1720,8 @@ func (r resourceCluster) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 	}
 }
 
-func getClusterRegionIndex(region string, readOnly bool, regionIndexMap map[string]int, localIndex int) (index int) {
-	if readOnly {
+func getClusterRegionIndex(region string, regionIndexMap map[string]int, localIndex int) (index int) {
+	if len(regionIndexMap) == 0 {
 		return localIndex
 	}
 	index, ok := regionIndexMap[region]
@@ -1950,7 +1950,7 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 	clusterRegionInfo := make([]RegionInfo, len(respClusterRegionInfo))
 	for localIndex, info := range respClusterRegionInfo {
 		region := info.PlacementInfo.CloudInfo.GetRegion()
-		destIndex := getClusterRegionIndex(region, readOnly, regionIndexMap, localIndex)
+		destIndex := getClusterRegionIndex(region, regionIndexMap, localIndex)
 		if destIndex < len(respClusterRegionInfo) {
 			vpcID := info.PlacementInfo.GetVpcId()
 			vpcName := ""
@@ -1993,9 +1993,8 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 
 	if allowListProvided {
 		const maxRetries = 5
-
 		for attempt := 0; attempt < maxRetries; attempt++ {
-			clusterAllowListMappingResp, response, err := apiClient.ClusterApi.ListClusterNetworkAllowLists(context.Background(), accountId, projectId, clusterId).Execute()
+			clusterAllowListMappingResp, response, err := apiClient.ClusterApi.ListClusterNetworkAllowLists(ctx, accountId, projectId, clusterId).Execute()
 			if err != nil {
 				errMsg := getErrorMessage(response, err)
 				return cluster, false, errMsg
@@ -2013,7 +2012,7 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 						allowListStrings = append(allowListStrings, elem)
 					}
 				}
-				tflog.Debug(context.Background(), fmt.Sprintf("Attempt %d: Input Allow List is %v, Server Allow List is %v", attempt+1, inputAllowListIDs, allowListStrings))
+				tflog.Debug(ctx, fmt.Sprintf("Attempt %d: Input Allow List is %v, Server Allow List is %v", attempt+1, inputAllowListIDs, allowListStrings))
 				//added len(inputAllowListIDs)==0 in if condition so that we can reuse the func resourceClusterRead in data_source_cluster_name.go.
 				if util.AreListsEqual(allowListStrings, inputAllowListIDs) || len(inputAllowListIDs) == 0 {
 					for _, elem := range allowListStrings {
@@ -2038,7 +2037,7 @@ func resourceClusterRead(ctx context.Context, accountId string, projectId string
 
 			// Don't sleep on the last attempt
 			if attempt < maxRetries-1 {
-				time.Sleep(2 * time.Second)
+				time.Sleep(10 * time.Second)
 			}
 		}
 
@@ -2201,7 +2200,7 @@ func (r resourceCluster) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 		return
 	}
 	clusterSpec.ClusterInfo.SetVersion(int32(clusterVersion))
-	_, response, err := apiClient.ClusterApi.EditCluster(context.Background(), accountId, projectId, clusterId).ClusterSpec(*clusterSpec).Execute()
+	_, response, err := apiClient.ClusterApi.EditCluster(ctx, accountId, projectId, clusterId).ClusterSpec(*clusterSpec).Execute()
 	if err != nil {
 		errMsg := getErrorMessage(response, err)
 		if len(errMsg) > 10000 {

--- a/managed/resource_read_replica.go
+++ b/managed/resource_read_replica.go
@@ -315,7 +315,7 @@ func (r resourceReadReplicas) Create(ctx context.Context, req tfsdk.CreateResour
 		regions = append(regions, readReplica.Region.Value)
 	}
 
-	readReplicas, readOK, message := resourceReadReplicasRead(ctx, accountId, projectId, clusterId, apiClient, regions, false)
+	readReplicas, readOK, message := resourceReadReplicasRead(ctx, accountId, projectId, clusterId, apiClient, regions)
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the read replicas", message)
 		return
@@ -341,7 +341,7 @@ func (r resourceReadReplicas) Read(ctx context.Context, req tfsdk.ReadResourceRe
 		regions = append(regions, readReplica.Region.Value)
 	}
 
-	readReplicas, readOK, message := resourceReadReplicasRead(ctx, accountId, projectId, clusterId, r.p.client, regions, false)
+	readReplicas, readOK, message := resourceReadReplicasRead(ctx, accountId, projectId, clusterId, r.p.client, regions)
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the read replica", message)
 		return
@@ -354,7 +354,7 @@ func (r resourceReadReplicas) Read(ctx context.Context, req tfsdk.ReadResourceRe
 	}
 }
 
-func resourceReadReplicasRead(ctx context.Context, accountId string, projectId string, clusterId string, apiClient *openapiclient.APIClient, planRegions []string, isReadOnly bool) (readReplicas ReadReplicas, readOK bool, errorMessage string) {
+func resourceReadReplicasRead(ctx context.Context, accountId string, projectId string, clusterId string, apiClient *openapiclient.APIClient, planRegions []string) (readReplicas ReadReplicas, readOK bool, errorMessage string) {
 
 	listReadReplicasResp, response, err := apiClient.ReadReplicaApi.ListReadReplicas(context.Background(), accountId, projectId, clusterId).Execute()
 	if err != nil {
@@ -414,7 +414,7 @@ func resourceReadReplicasRead(ctx context.Context, accountId string, projectId s
 			readReplicaInfo.Endpoint.Value = endpoints[localIndex].GetHost()
 		}
 
-		destIndex := getClusterRegionIndex(readReplicaInfo.Region.Value, isReadOnly, regionIndexMap, localIndex)
+		destIndex := getClusterRegionIndex(readReplicaInfo.Region.Value, regionIndexMap, localIndex)
 		readReplicasInfo[destIndex] = readReplicaInfo
 
 	}
@@ -515,7 +515,7 @@ func (r resourceReadReplicas) Update(ctx context.Context, req tfsdk.UpdateResour
 		regions = append(regions, readReplicaInfo.Region.Value)
 	}
 
-	readReplicas, readOK, message := resourceReadReplicasRead(ctx, accountId, projectId, clusterId, apiClient, regions, false)
+	readReplicas, readOK, message := resourceReadReplicasRead(ctx, accountId, projectId, clusterId, apiClient, regions)
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the read replicas", message)
 		return


### PR DESCRIPTION
Get cluster region without using the `readOnly` parameter. Determine the difference between cluster data source and resource based on the region index map.