### PR TITLE
[CLOUDGA-22307][CLOUDGA-26768] Retry 503 errors during cluster edits, calculate edit cluster timeout based on nodes count.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250831172447-5c49b6ceed87
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250922172606-58fffb29a849
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250831172447-5c49b6ceed87 h1:y5Rvth18Ur7WHZd7Ukf5ynLmBtR/n7UPmiU//q/5Rkk=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250831172447-5c49b6ceed87/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250922172606-58fffb29a849 h1:kW+rPEhcxlkhDU8q1fg3GRm/ce9lq5HMzrN4M6j1mOU=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20250922172606-58fffb29a849/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
[CLOUDGA-22307](https://yugabyte.atlassian.net/browse/CLOUDGA-22307) : [Terraform] Retry 503 errors in Terraform.
[CLOUDGA-26768](https://yugabyte.atlassian.net/browse/CLOUDGA-26768) : Unable to modify the cluster due to a timeout issue after 1 hr.