### PR TITLE
[CLOUDGA-29573] Removed usage of deprecated 'archives.format' in Go Releaser.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ git:
   tag_sort: -v:creatordate
 
 archives:
-- format: zip
+- formats: [ 'zip' ]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:


### PR DESCRIPTION
[CLOUDGA-29573](https://yugabyte.atlassian.net/browse/CLOUDGA-29573) : Removed usage of deprecated 'archives.format' in Go Releaser.

Ref : https://goreleaser.com/deprecations/#archivesformat