### PR TITLE
[CLOUDGA-33503] [CLOUDGA-33505] Backup_restore resource minor improvements and fixes

### DIFF
--- a/managed/models.go
+++ b/managed/models.go
@@ -225,7 +225,7 @@ type BackupRestore struct {
 	AccountID           types.String          `tfsdk:"account_id"`
 	ProjectID           types.String          `tfsdk:"project_id"`
 	BackupID            types.String          `tfsdk:"backup_id"`
-	ClusterID           types.String          `tfsdk:"cluster_id"`
+	TargetClusterID     types.String          `tfsdk:"target_cluster_id"`
 	UseRoles            types.Bool            `tfsdk:"use_roles"`
 	YSQLDatabases       []types.String        `tfsdk:"ysql_databases"`
 	YCQLKeyspaces       []types.String        `tfsdk:"ycql_keyspaces"`

--- a/managed/resource_backup_restore.go
+++ b/managed/resource_backup_restore.go
@@ -47,8 +47,8 @@ func (r resourceBackupRestoreType) GetSchema(_ context.Context) (tfsdk.Schema, d
 					tfsdk.RequiresReplace(),
 				},
 			},
-			"cluster_id": {
-				Description: "The ID of the cluster to restore to.",
+			"target_cluster_id": {
+				Description: "The ID of the cluster to restore the backup onto.",
 				Type:        types.StringType,
 				Required:    true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -139,7 +139,7 @@ type resourceBackupRestore struct {
 func getBackupRestorePlan(ctx context.Context, plan tfsdk.Plan, br *BackupRestore) diag.Diagnostics {
 	var diags diag.Diagnostics
 	diags.Append(plan.GetAttribute(ctx, path.Root("backup_id"), &br.BackupID)...)
-	diags.Append(plan.GetAttribute(ctx, path.Root("cluster_id"), &br.ClusterID)...)
+	diags.Append(plan.GetAttribute(ctx, path.Root("target_cluster_id"), &br.TargetClusterID)...)
 	diags.Append(plan.GetAttribute(ctx, path.Root("use_roles"), &br.UseRoles)...)
 	diags.Append(plan.GetAttribute(ctx, path.Root("ysql_databases"), &br.YSQLDatabases)...)
 	diags.Append(plan.GetAttribute(ctx, path.Root("ycql_keyspaces"), &br.YCQLKeyspaces)...)
@@ -151,7 +151,7 @@ func getBackupRestorePlan(ctx context.Context, plan tfsdk.Plan, br *BackupRestor
 func buildRestoreSpec(plan *BackupRestore) *openapiclient.RestoreSpec {
 	restoreSpec := openapiclient.NewRestoreSpec()
 	restoreSpec.SetBackupId(plan.BackupID.Value)
-	restoreSpec.SetClusterId(plan.ClusterID.Value)
+	restoreSpec.SetClusterId(plan.TargetClusterID.Value)
 	restoreSpec.SetUseRoles(plan.UseRoles.Value)
 
 	hasYSQL := len(plan.YSQLDatabases) > 0
@@ -238,8 +238,8 @@ func (r resourceBackupRestore) Create(ctx context.Context, req tfsdk.CreateResou
 
 	restoreSpec := buildRestoreSpec(&plan)
 	tflog.Debug(ctx, "Restoring backup to cluster", map[string]interface{}{
-		"backup_id":  plan.BackupID.Value,
-		"cluster_id": plan.ClusterID.Value,
+		"backup_id":         plan.BackupID.Value,
+		"target_cluster_id": plan.TargetClusterID.Value,
 	})
 
 	restoreResp, response, err := apiClient.BackupApi.RestoreBackup(ctx, accountId, projectId).RestoreSpec(*restoreSpec).Execute()
@@ -296,7 +296,7 @@ func (r resourceBackupRestore) Read(ctx context.Context, req tfsdk.ReadResourceR
 	var state BackupRestore
 	getIDsFromBackupRestoreState(ctx, req.State, &state)
 	req.State.GetAttribute(ctx, path.Root("backup_id"), &state.BackupID)
-	req.State.GetAttribute(ctx, path.Root("cluster_id"), &state.ClusterID)
+	req.State.GetAttribute(ctx, path.Root("target_cluster_id"), &state.TargetClusterID)
 	req.State.GetAttribute(ctx, path.Root("use_roles"), &state.UseRoles)
 	req.State.GetAttribute(ctx, path.Root("ysql_databases"), &state.YSQLDatabases)
 	req.State.GetAttribute(ctx, path.Root("ycql_keyspaces"), &state.YCQLKeyspaces)

--- a/managed/resource_backup_restore.go
+++ b/managed/resource_backup_restore.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -69,7 +71,8 @@ func (r resourceBackupRestoreType) GetSchema(_ context.Context) (tfsdk.Schema, d
 				Type: types.ListType{
 					ElemType: types.StringType,
 				},
-				Optional: true,
+				Optional:   true,
+				Validators: listOfNonEmptyStringValidators(),
 				PlanModifiers: []tfsdk.AttributePlanModifier{
 					tfsdk.RequiresReplace(),
 				},
@@ -79,7 +82,8 @@ func (r resourceBackupRestoreType) GetSchema(_ context.Context) (tfsdk.Schema, d
 				Type: types.ListType{
 					ElemType: types.StringType,
 				},
-				Optional: true,
+				Optional:   true,
+				Validators: listOfNonEmptyStringValidators(),
 				PlanModifiers: []tfsdk.AttributePlanModifier{
 					tfsdk.RequiresReplace(),
 				},
@@ -92,11 +96,13 @@ func (r resourceBackupRestoreType) GetSchema(_ context.Context) (tfsdk.Schema, d
 						Description: "YSQL database name in the backup.",
 						Type:        types.StringType,
 						Required:    true,
+						Validators:  nonEmptyStringValidators(),
 					},
 					"restore_database": {
 						Description: "YSQL database name to use on the restored cluster.",
 						Type:        types.StringType,
 						Required:    true,
+						Validators:  nonEmptyStringValidators(),
 					},
 				}),
 				PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -111,11 +117,13 @@ func (r resourceBackupRestoreType) GetSchema(_ context.Context) (tfsdk.Schema, d
 						Description: "YCQL keyspace name in the backup.",
 						Type:        types.StringType,
 						Required:    true,
+						Validators:  nonEmptyStringValidators(),
 					},
 					"restore_database": {
 						Description: "YCQL keyspace name to use on the restored cluster.",
 						Type:        types.StringType,
 						Required:    true,
+						Validators:  nonEmptyStringValidators(),
 					},
 				}),
 				PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -332,4 +340,18 @@ func (r resourceBackupRestore) Update(ctx context.Context, req tfsdk.UpdateResou
 func (r resourceBackupRestore) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
 	// Delete only removes the resource from Terraform state; it does not call an API to "undo" the restore.
 	resp.State.RemoveResource(ctx)
+}
+
+// listOfNonEmptyStringValidators rejects empty string elements in list(string) attributes.
+func listOfNonEmptyStringValidators() []tfsdk.AttributeValidator {
+	return []tfsdk.AttributeValidator{
+		listvalidator.ValuesAre(stringvalidator.LengthAtLeast(1)),
+	}
+}
+
+// nonEmptyStringValidators rejects "" for string attributes (e.g. rename names).
+func nonEmptyStringValidators() []tfsdk.AttributeValidator {
+	return []tfsdk.AttributeValidator{
+		stringvalidator.LengthAtLeast(1),
+	}
 }


### PR DESCRIPTION
## Summary

- [CLOUDGA-33503] Do not allow empty string as database name for backup_restore resource as it leads to validation error in backend.
- [CLOUDGA-33505] Change restore_id to restore_cluster_id for backup restore resource to avoid ambiguity.

[CLOUDGA-33503]: https://yugabyte.atlassian.net/browse/CLOUDGA-33503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUDGA-33505]: https://yugabyte.atlassian.net/browse/CLOUDGA-33505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ