### PR TITLE
[CLOUDGA-26346] Read user's role from userResp->Data->RoleInfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260507084041-0c65f003aceb
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260522182635-021c48e99255
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260507084041-0c65f003aceb h1:OtV7qkO56m+q43lS5tXMxmyOibhg2EHzKAinnmpVUb0=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260507084041-0c65f003aceb/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260522182635-021c48e99255 h1:Pc/QKZfhDvKQLoypzpTmsZfwrnahI7dC63BxWH0+Cd4=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260522182635-021c48e99255/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/resource_user.go
+++ b/managed/resource_user.go
@@ -198,7 +198,7 @@ func resourceUserRead(accountId string, projectId string, email string, userId s
 	user.ProjectID.Value = projectId
 	user.UserID.Value = userId
 	user.Email.Value = email
-	user.RoleName.Value = userResp.Data[0].Info.GetRoleList()[0].GetRoles()[0].Info.GetDisplayName()
+	user.RoleName.Value = userResp.Data[0].GetRoleInfo()[0].GetDisplayName()
 	user.UserName.Value = userResp.Data[0].Spec.GetFirstName() + userResp.Data[0].Spec.GetLastName()
 	user.UserState.Value = string(userResp.Data[0].Info.State)
 

--- a/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
+++ b/mock_yugabytedb_managed_go_client_internal/mock_api_account.go
@@ -66,36 +66,6 @@ func (mr *MockAccountApiMockRecorder) BatchInviteAccountUsersExecute(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchInviteAccountUsersExecute", reflect.TypeOf((*MockAccountApi)(nil).BatchInviteAccountUsersExecute), arg0)
 }
 
-// GetAccountQuotas mocks base method.
-func (m *MockAccountApi) GetAccountQuotas(arg0 context.Context, arg1 string) openapi.ApiGetAccountQuotasRequest {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccountQuotas", arg0, arg1)
-	ret0, _ := ret[0].(openapi.ApiGetAccountQuotasRequest)
-	return ret0
-}
-
-// GetAccountQuotas indicates an expected call of GetAccountQuotas.
-func (mr *MockAccountApiMockRecorder) GetAccountQuotas(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountQuotas", reflect.TypeOf((*MockAccountApi)(nil).GetAccountQuotas), arg0, arg1)
-}
-
-// GetAccountQuotasExecute mocks base method.
-func (m *MockAccountApi) GetAccountQuotasExecute(arg0 openapi.ApiGetAccountQuotasRequest) (openapi.AccountQuotaResponse, *http.Response, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAccountQuotasExecute", arg0)
-	ret0, _ := ret[0].(openapi.AccountQuotaResponse)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetAccountQuotasExecute indicates an expected call of GetAccountQuotasExecute.
-func (mr *MockAccountApiMockRecorder) GetAccountQuotasExecute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountQuotasExecute", reflect.TypeOf((*MockAccountApi)(nil).GetAccountQuotasExecute), arg0)
-}
-
 // GetAllowedLoginTypes mocks base method.
 func (m *MockAccountApi) GetAllowedLoginTypes(arg0 context.Context, arg1 string) openapi.ApiGetAllowedLoginTypesRequest {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

Reads the user's role display name from userResp.Data[0].GetRoleInfo(). Bumps the Go client and regenerates `AccountApi` mocks.

## Test plan

Tested build and manual test
