### PR TITLE
[CLOUDGA-33933] [CLOUDGA-33479] Support old track names with new track naming to ensure backward compatibility

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -993,7 +993,11 @@ resource "ybm_cluster" "cluster_without_backup_replication" {
 - `credentials` (Attributes) Credentials to be used by the database. Required only at the time of creation. Please provide 'username' and 'password' 
 (which would be used in common for both YSQL and YCQL) OR all of 'ysql_username',
 'ysql_password', 'ycql_username' and 'ycql_password' but not a mix of both. (see [below for nested schema](#nestedatt--credentials))
-- `database_track` (String) The track of the database. Production or Innovation or Preview.
+- `database_track` (String) Database software release track for the cluster. Supported values are `Extended` and `Rapid`.
+
+> **Note:** Deprecated track names are still accepted for backward compatibility, but should be updated in configuration.
+> - `Production` and `Innovation` are deprecated in favor of `Extended`.
+> - `Preview` and `Early Access` are deprecated in favor of `Rapid`.
 - `desired_connection_pooling_state` (String) The desired connection pooling state of the cluster, Enabled or Disabled. Can be used during or after cluster creation.
 - `desired_state` (String) The desired state of the cluster, Active or Paused. This parameter can be used to pause/resume a cluster.
 - `fault_tolerance` (String) The fault tolerance of the cluster. NONE, NODE, ZONE or REGION.

--- a/managed/common.go
+++ b/managed/common.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	openapiclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
 )
@@ -94,12 +95,14 @@ func getTrackId(ctx context.Context, apiClient *openapiclient.APIClient, account
 
 	for _, track := range tracksData {
 		tflog.Debug(ctx, fmt.Sprintf("Required track name:  %v, current track name: %v", track.Spec.GetName(), trackName))
-		if track.Spec.GetName() == trackName || (track.Spec.GetName() == "Production" && trackName == "Stable") {
+		if track.Spec.GetName() == trackName ||
+			(track.Spec.GetName() == "Extended" && (trackName == "Production" || trackName == "Innovation")) ||
+			(track.Spec.GetName() == "Rapid" && (trackName == "Preview" || trackName == "Early Access")) {
 			return track.Info.GetId(), true, ""
 		}
 	}
 
-	return "", false, "The database version doesn't exist."
+	return "", false, "The database track doesn't exist."
 }
 
 func getTrackName(ctx context.Context, apiClient *openapiclient.APIClient, accountId string, trackId string) (trackName string, trackNameOK bool, errorMessage string) {
@@ -113,6 +116,29 @@ func getTrackName(ctx context.Context, apiClient *openapiclient.APIClient, accou
 	trackName = trackData.Spec.GetName()
 
 	return trackName, true, ""
+}
+
+func databaseTrackPriorValue(track types.String) string {
+	if track.IsNull() || track.IsUnknown() {
+		return ""
+	}
+	return track.Value
+}
+
+// databaseTrackNameForState returns the value to store in Terraform state for database_track.
+// When priorTrackName is a deprecated alias (e.g. Production) that maps to the same track ID as
+// the cluster's current track, the prior name is preserved so config and state stay aligned.
+func databaseTrackNameForState(ctx context.Context, apiClient *openapiclient.APIClient, accountId string, apiTrackID string, priorTrackName string) (trackName string, trackNameOK bool, errorMessage string) {
+	apiTrackName, ok, msg := getTrackName(ctx, apiClient, accountId, apiTrackID)
+	if !ok {
+		return "", false, msg
+	}
+	if priorTrackName != "" {
+		if priorTrackID, priorOK, _ := getTrackId(ctx, apiClient, accountId, priorTrackName); priorOK && priorTrackID == apiTrackID {
+			return priorTrackName, true, ""
+		}
+	}
+	return apiTrackName, true, ""
 }
 
 func getAccountId(ctx context.Context, apiClient *openapiclient.APIClient) (accountId string, accountIdOK bool, errorMessage string) {

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -807,7 +807,7 @@ func (r dataClusterName) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 		ScheduleID: types.String{Value: scheduleId},
 	}
 	backUpSchedule = append(backUpSchedule, backUpInfo)
-	cluster, readOK, message := resourceClusterRead(ctx, clusterId, backUpSchedule, make([]string, 0), true, make([]string, 0), true, apiClient)
+	cluster, readOK, message := resourceClusterRead(ctx, clusterId, backUpSchedule, make([]string, 0), true, make([]string, 0), true, "", apiClient)
 
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the cluster", message)

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -856,10 +856,14 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 			Computed: true,
 		},
 		"database_track": {
-			Description: "The track of the database. Production or Innovation or Preview.",
-			Type:        types.StringType,
-			Optional:    true,
-			Computed:    true,
+			Description: "Database software release track for the cluster. Supported values are Extended and Rapid. Deprecated values are still accepted for backward compatibility: Production and Innovation map to Extended; Preview and Early Access map to Rapid.",
+			MarkdownDescription: "Database software release track for the cluster. Supported values are `Extended` and `Rapid`.\n\n" +
+				"> **Note:** Deprecated track names are still accepted for backward compatibility, but should be updated in configuration.\n" +
+				"> - `Production` and `Innovation` are deprecated in favor of `Extended`.\n" +
+				"> - `Preview` and `Early Access` are deprecated in favor of `Rapid`.",
+			Type:     types.StringType,
+			Optional: true,
+			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
 			},
@@ -1369,6 +1373,7 @@ func getIDsFromState(ctx context.Context, state tfsdk.State, cluster *Cluster) {
 	state.GetAttribute(ctx, path.Root("account_id"), &cluster.AccountID)
 	state.GetAttribute(ctx, path.Root("project_id"), &cluster.ProjectID)
 	state.GetAttribute(ctx, path.Root("cluster_id"), &cluster.ClusterID)
+	state.GetAttribute(ctx, path.Root("database_track"), &cluster.DatabaseTrack)
 	state.GetAttribute(ctx, path.Root("desired_state"), &cluster.DesiredState)
 	state.GetAttribute(ctx, path.Root("desired_connection_pooling_state"), &cluster.DesiredConnectionPoolingState)
 	state.GetAttribute(ctx, path.Root("cluster_allow_list_ids"), &cluster.ClusterAllowListIDs)
@@ -1802,7 +1807,8 @@ func (r resourceCluster) Create(ctx context.Context, req tfsdk.CreateResourceReq
 	// Connection pooling is now enabled during cluster creation via features parameter
 	// No need for post-creation enablement call
 
-	cluster, readOK, message := resourceClusterRead(ctx, clusterId, backUpSchedules, regions, allowListProvided, allowListIDs, false, apiClient)
+	priorDatabaseTrack := databaseTrackPriorValue(plan.DatabaseTrack)
+	cluster, readOK, message := resourceClusterRead(ctx, clusterId, backUpSchedules, regions, allowListProvided, allowListIDs, false, priorDatabaseTrack, apiClient)
 
 	// Update the State file with the unmasked creds for AWS (secret key,access) and GCP (client id,private key)
 	if plan.CMKSpec != nil {
@@ -2129,7 +2135,8 @@ func (r resourceCluster) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 		backUpSchedules = append(backUpSchedules, state.BackupSchedules[0])
 	}
 
-	cluster, readOK, message := resourceClusterRead(ctx, state.ClusterID.Value, backUpSchedules, regions, allowListProvided, allowListIDs, true, r.p.client)
+	priorDatabaseTrack := databaseTrackPriorValue(state.DatabaseTrack)
+	cluster, readOK, message := resourceClusterRead(ctx, state.ClusterID.Value, backUpSchedules, regions, allowListProvided, allowListIDs, true, priorDatabaseTrack, r.p.client)
 	tflog.Debug(ctx, "Cluster Read: Allow List IDs read from API server", map[string]interface{}{
 		"Allow List IDs": cluster.ClusterAllowListIDs})
 	// Fetch the cmkSpec information from State (to get unmasked creds)
@@ -2223,7 +2230,7 @@ func readBackupScheduleInfoV2(ctx context.Context, apiClient *openapiclient.APIC
 	return backupScheduleInfo, nil, nil
 }
 
-func resourceClusterRead(ctx context.Context, clusterId string, backUpSchedules []BackupScheduleInfo, regions []string, allowListProvided bool, inputAllowListIDs []string, readOnly bool, apiClient *openapiclient.APIClient) (cluster Cluster, readOK bool, errorMessage string) {
+func resourceClusterRead(ctx context.Context, clusterId string, backUpSchedules []BackupScheduleInfo, regions []string, allowListProvided bool, inputAllowListIDs []string, readOnly bool, priorDatabaseTrack string, apiClient *openapiclient.APIClient) (cluster Cluster, readOK bool, errorMessage string) {
 	var accountId, projectId, message string
 	var getAccountOK, getProjectOK bool
 
@@ -2361,9 +2368,9 @@ func resourceClusterRead(ctx context.Context, clusterId string, backUpSchedules 
 	cluster.ClusterTier.Value = string(clusterResp.Data.Spec.ClusterInfo.ClusterTier)
 	cluster.ClusterVersion.Value = strconv.Itoa(int(clusterResp.Data.Spec.ClusterInfo.GetVersion()))
 
-	// set database track name
+	// set database track name (preserve deprecated alias from config/state when semantically equal)
 	trackId := clusterResp.Data.Spec.SoftwareInfo.GetTrackId()
-	trackName, trackNameOK, message := getTrackName(ctx, apiClient, accountId, trackId)
+	trackName, trackNameOK, message := databaseTrackNameForState(ctx, apiClient, accountId, trackId, priorDatabaseTrack)
 	if !trackNameOK {
 		return cluster, false, message
 	}
@@ -2955,7 +2962,11 @@ func (r resourceCluster) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 		regions = append(regions, regionInfo.Region.Value)
 	}
 
-	cluster, readOK, message := resourceClusterRead(ctx, clusterId, backUpSchedules, regions, allowListProvided, allowListIDs, false, apiClient)
+	priorDatabaseTrack := databaseTrackPriorValue(plan.DatabaseTrack)
+	if priorDatabaseTrack == "" {
+		priorDatabaseTrack = databaseTrackPriorValue(state.DatabaseTrack)
+	}
+	cluster, readOK, message := resourceClusterRead(ctx, clusterId, backUpSchedules, regions, allowListProvided, allowListIDs, false, priorDatabaseTrack, apiClient)
 	if !readOK {
 		resp.Diagnostics.AddError("Unable to read the state of the cluster ", message)
 		return


### PR DESCRIPTION
## Summary

Adds backward-compatible support for deprecated YugabyteDB Aeon database track names in `ybm_cluster`, while canonical track names remain `Extended` and `Rapid`.

Customers can keep using legacy values such as `Production`, `Innovation`, `Preview`, `Early Access`, and `Stable` in Terraform configuration without perpetual plan drift or spurious updates after refresh.

## Approach

Compare tracks by **track ID**, not display string:

1. **Write path (create/update):** Continue resolving `database_track` from config through `getTrackId` so the API receives the correct track ID.
2. **Read path:** After fetching the cluster’s track ID from the API, if the prior value from config/state resolves to the **same** track ID, preserve that prior name in state; otherwise store the canonical API name.

This keeps legacy aliases working in `.tf` files while the backend still operates on track IDs.

### Track name mapping

| Category | Terraform value | Resolves to (API track) |
|----------|-----------------|-------------------------|
| **Supported** | `Extended` | Extended |
| **Supported** | `Rapid` | Rapid |
| **Deprecated** | `Production` | Extended |
| **Deprecated** | `Innovation` | Extended |
| **Deprecated** | `Stable` | Extended |
| **Deprecated** | `Preview` | Rapid |
| **Deprecated** | `Early Access` | Rapid |

## Behavior by operation

| Operation | Prior name source | State `database_track` after operation |
|-----------|-------------------|----------------------------------------|
| **Create** | Plan (`database_track` from config) | Preserved alias if it maps to the cluster’s track ID (e.g. `Production`); otherwise canonical API name |
| **Read / refresh** | State (must be loaded via `getIDsFromState`) | Same as create: preserve alias from state when semantically equal to API track |
| **Update** | Plan first, then state if plan is null/unknown | Reflects new config intent (e.g. migration `Production` → `Extended` updates state); otherwise keeps existing alias |

### Example: config uses `database_track = "Production"`

| Step | Config | State | Notes |
|------|--------|-------|-------|
| After create | `Production` | `Production` | API uses Extended track ID |
| After refresh | `Production` | `Production` | No drift |
| User changes to `Extended` | `Extended` | `Extended` | Cosmetic rename; same track ID |
| Import (empty prior) | `Production` | `Extended` | Until config sets alias; then preserved on next read |

## Documentation changes
<img width="1098" height="135" alt="image" src="https://github.com/user-attachments/assets/61d1c657-94d8-4de8-950e-fd5fa0e5d292" />


## Testing steps

- Create cluster with `database_track = "Production"` → state remains `Production`.
- `terraform refresh` → no `database_track` drift.
- Update unrelated attribute → `database_track` unchanged in plan/state.
- Change config `Production` → `Extended` → one apply updates state to `Extended`; subsequent plans clean.
- Import existing cluster and align config with deprecated or canonical name.