### PR TITLE
[CLOUDGA-34533] Set restore_backup_id during read without checking the state

### DIFF
--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -2189,9 +2189,8 @@ func (r resourceCluster) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 	// set credentials for cluster (not returned by read api)
 	req.State.GetAttribute(ctx, path.Root("credentials"), &cluster.Credentials)
 	// set restore backup id for cluster (not returned by read api)
-	if !state.RestoreBackupID.Null {
-		req.State.GetAttribute(ctx, path.Root("restore_backup_id"), &cluster.RestoreBackupID)
-	}
+	req.State.GetAttribute(ctx, path.Root("restore_backup_id"), &cluster.RestoreBackupID)
+
 	diags := resp.State.Set(ctx, &cluster)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
## Summary
After the `restore_backup_id` deprecation changes, `terraform plan` showed a spurious in-place update on `ybm_cluster` even when config was unchanged.

**Cause**: `getIDsFromState` started loading `restore_backup_id` as proper `null`, but Read only preserved it when `!state.RestoreBackupID.Null`. For clusters without a restore ID, Read skipped preservation and wrote `""` instead of null, causing plan drift.

**Fix**: Always preserve `restore_backup_id` from prior state in Read.

## Test
Tested `terraform plan` locally and it doesn't show any plan changes for a cluster if nothing is changed.