### PR TITLE
[CLOUDGA-34616] Role Name checks for exact string match during user invite / modify operation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260522182635-021c48e99255
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260624085420-56b94ab07f90
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260522182635-021c48e99255 h1:Pc/QKZfhDvKQLoypzpTmsZfwrnahI7dC63BxWH0+Cd4=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260522182635-021c48e99255/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260624085420-56b94ab07f90 h1:fS4TmKpn0tBdriLTpXJwtS5N4pnzR2VYRiLMYXLqj7g=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260624085420-56b94ab07f90/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/resource_user.go
+++ b/managed/resource_user.go
@@ -6,6 +6,7 @@ package managed
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -132,10 +133,10 @@ func (r resourceUser) Create(ctx context.Context, req tfsdk.CreateResourceReques
 		resp.Diagnostics.AddError("Unable to invite user", errMsg)
 		return
 	}
-	if len(roleResp.Data) < 1 {
+	if len(roleResp.Data) < 1 || roleResp.Data[0].Info.GetDisplayName() != roleName {
 		resp.Diagnostics.AddError(
 			"Unable to invite user",
-			"The role provided for the user to be invited does not exist.",
+			fmt.Sprintf("The role '%s' does not exist.", roleName),
 		)
 		return
 	}
@@ -262,10 +263,10 @@ func (r resourceUser) Update(ctx context.Context, req tfsdk.UpdateResourceReques
 		resp.Diagnostics.AddError("Unable to modify user role", errMsg)
 		return
 	}
-	if len(roleResp.Data) < 1 {
+	if len(roleResp.Data) < 1 || roleResp.Data[0].Info.GetDisplayName() != roleName {
 		resp.Diagnostics.AddError(
 			"Unable to modify user role",
-			"The role provided for the user does not exist.",
+			fmt.Sprintf("The role '%s' does not exist.", roleName),
 		)
 		return
 	}


### PR DESCRIPTION
[CLOUDGA-34616](https://yugabyte.atlassian.net/browse/CLOUDGA-34616) : Role Name checks for exact string match during user invite / modify operation.

Before : 

Original role display name : `My Custom Role`
```
Plan: 0 to add, 1 to change, 0 to destroy.
ybm_user.user: Modifying...
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to ybm_user.user, provider "provider[\"registry.terraform.io/yugabyte/ybm\"]" produced an unexpected new value: .role_name: was
│ cty.StringVal("My custom Role"), but now cty.StringVal("My Custom Role").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

After : 
```
Plan: 0 to add, 1 to change, 0 to destroy.
ybm_user.user: Modifying...
╷
│ Error: Unable to modify user role
│ 
│   with ybm_user.user,
│   on main.tf line 37, in resource "ybm_user" "user":
│   37: resource "ybm_user" "user" {
│ 
│ The role 'My custom Role' does not exist.
```

[CLOUDGA-34616]: https://yugabyte.atlassian.net/browse/CLOUDGA-34616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ