### PR TITLE
[CLOUDGA-34394] Support configuring number of zones per region in cluster

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -225,6 +225,7 @@ Read-Only:
 - `is_preferred` (Boolean)
 - `num_cores` (Number)
 - `num_nodes` (Number)
+- `num_zones` (Number) Number of zones in the region.
 - `public_access` (Boolean)
 - `region` (String)
 - `vpc_id` (String)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1031,6 +1031,7 @@ Optional:
 - `is_default` (Boolean)
 - `is_preferred` (Boolean)
 - `num_cores` (Number) Number of CPU cores in the nodes of the region.
+- `num_zones` (Number) Number of zones in the region.
 - `public_access` (Boolean)
 - `vpc_id` (String)
 - `vpc_name` (String)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260624085420-56b94ab07f90
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260703135719-696638194cb7
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260624085420-56b94ab07f90 h1:fS4TmKpn0tBdriLTpXJwtS5N4pnzR2VYRiLMYXLqj7g=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260624085420-56b94ab07f90/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260703135719-696638194cb7 h1:Jcyz4+GQbqyE6DmvjfFbBJlOv/0s+gumzzocT/dOg3k=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260703135719-696638194cb7/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/data_source_cluster_name.go
+++ b/managed/data_source_cluster_name.go
@@ -64,6 +64,11 @@ func (r dataClusterNameType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 						Type:     types.StringType,
 						Computed: true,
 					},
+					"num_zones": {
+						Description: "Number of zones in the region.",
+						Type:        types.Int64Type,
+						Computed:    true,
+					},
 					"num_cores": {
 						Type:     types.Int64Type,
 						Computed: true,

--- a/managed/fflags/feature_flags.go
+++ b/managed/fflags/feature_flags.go
@@ -15,11 +15,13 @@ type FeatureFlag string
 const (
 	DR                   FeatureFlag = "DR"
 	GCPBackupReplication FeatureFlag = "GCP_BACKUP_REPLICATION"
+	MultiZoneSupport     FeatureFlag = "MULTI_ZONE_SUPPORT"
 )
 
 var flagEnabled = map[FeatureFlag]bool{
 	DR:                   false,
 	GCPBackupReplication: false,
+	MultiZoneSupport:     false,
 }
 
 func (f FeatureFlag) String() string {

--- a/managed/models.go
+++ b/managed/models.go
@@ -100,6 +100,7 @@ type RegionInfo struct {
 	Region                     types.String `tfsdk:"region"`
 	NumNodes                   types.Int64  `tfsdk:"num_nodes"`
 	NumCores                   types.Int64  `tfsdk:"num_cores"`
+	NumZones                   types.Int64  `tfsdk:"num_zones"`
 	DiskSizeGb                 types.Int64  `tfsdk:"disk_size_gb"`
 	DiskIops                   types.Int64  `tfsdk:"disk_iops"`
 	VPCID                      types.String `tfsdk:"vpc_id"`

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -105,6 +105,12 @@ func (r resourceClusterType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 					Type:     types.StringType,
 					Required: true,
 				},
+				"num_zones": {
+					Description: "Number of zones in the region.",
+					Type:        types.Int64Type,
+					Optional:    true,
+					Computed:    true,
+				},
 				"num_cores": {
 					Description: "Number of CPU cores in the nodes of the region.",
 					Type:        types.Int64Type,
@@ -960,6 +966,8 @@ type resourceCluster struct {
 	p provider
 }
 
+var _ tfsdk.ResourceWithValidateConfig = resourceCluster{}
+
 func EditBackupSchedule(ctx context.Context, backupScheduleStruct BackupScheduleInfo, scheduleId string, backupDes string, accountId string, projectId string, clusterId string, apiClient *openapiclient.APIClient) error {
 	return editBackupScheduleV2(ctx, backupScheduleStruct, scheduleId, backupDes, accountId, projectId, clusterId, apiClient)
 }
@@ -1138,6 +1146,12 @@ func createClusterSpec(ctx context.Context, apiClient *openapiclient.APIClient, 
 
 		if clusterType == "SYNCHRONOUS" {
 			info.PlacementInfo.SetMultiZone(false)
+		}
+
+		if fflags.IsFeatureFlagEnabled(fflags.MultiZoneSupport) {
+			if !regionInfo.NumZones.IsNull() && !regionInfo.NumZones.IsUnknown() {
+				info.PlacementInfo.SetNumZones(int32(regionInfo.NumZones.Value))
+			}
 		}
 		info.SetIsDefault(false)
 		info.SetIsAffinitized(false)
@@ -1504,6 +1518,18 @@ func createCmkSpec(plan Cluster) (*openapiclient.CMKSpec, error) {
 	cmkSpec.SetIsEnabled(plan.CMKSpec.IsEnabled.Value)
 
 	return cmkSpec, nil
+}
+
+func (r resourceCluster) ValidateConfig(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
+	var clusterRegionInfo []RegionInfo
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("cluster_region_info"), &clusterRegionInfo)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validateMultiZoneSupport(clusterRegionInfo); err != nil {
+		resp.Diagnostics.AddError("Invalid num_zones field", err.Error())
+	}
 }
 
 // Create a new resource
@@ -2493,9 +2519,17 @@ func resourceClusterRead(ctx context.Context, clusterId string, backUpSchedules 
 				}
 			}
 
+			var numZones types.Int64
+			if fflags.IsFeatureFlagEnabled(fflags.MultiZoneSupport) && info.PlacementInfo.HasNumZones() {
+				numZones = types.Int64{Value: int64(info.PlacementInfo.GetNumZones())}
+			} else {
+				numZones = types.Int64{Null: true}
+			}
+
 			regionInfo := RegionInfo{
 				Region:                     types.String{Value: region},
 				NumNodes:                   types.Int64{Value: int64(info.PlacementInfo.GetNumNodes())},
+				NumZones:                   numZones,
 				NumCores:                   types.Int64{Value: int64(info.NodeInfo.Get().GetNumCores())},
 				DiskSizeGb:                 types.Int64{Value: int64(info.NodeInfo.Get().GetDiskSizeGb())},
 				DiskIops:                   types.Int64{Value: int64(info.NodeInfo.Get().GetDiskIops())},
@@ -3092,42 +3126,14 @@ func (r resourceCluster) ImportState(ctx context.Context, req tfsdk.ImportResour
 	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("cluster_id"), req, resp)
 }
 
-func validateBackupReplicationTargets(clusterType string, clusterTier string, cloudType string, regionInfos []RegionInfo) error {
-	// Collect all non-empty backup replication targets
-	var regionGcpTargets []string
-	for _, regionInfo := range regionInfos {
-		if !regionInfo.BackupReplicationGCPTarget.IsNull() && !regionInfo.BackupReplicationGCPTarget.IsUnknown() && regionInfo.BackupReplicationGCPTarget.Value != "" {
-			regionGcpTargets = append(regionGcpTargets, regionInfo.BackupReplicationGCPTarget.Value)
+func validateMultiZoneSupport(clusterRegionInfo []RegionInfo) error {
+	for _, regionInfo := range clusterRegionInfo {
+		if !regionInfo.NumZones.IsNull() && !regionInfo.NumZones.IsUnknown() && !fflags.IsFeatureFlagEnabled(fflags.MultiZoneSupport) {
+			return fmt.Errorf(
+				"Multi-zone support feature disabled: The 'num_zones' field is set in cluster_region_info, but the MULTI_ZONE_SUPPORT feature flag is disabled. Set YBM_FF_MULTI_ZONE_SUPPORT=true to enable it.",
+			)
 		}
 	}
-
-	if len(regionGcpTargets) == 0 {
-		return nil
-	}
-
-	if clusterTier == "FREE" {
-		return fmt.Errorf("backup replication is not supported for free tier clusters")
-	}
-
-	if cloudType != "GCP" {
-		return fmt.Errorf("backup replication to GCS buckets is only supported for GCP clusters")
-	}
-
-	if len(regionGcpTargets) != len(regionInfos) {
-		return fmt.Errorf("all regions must have backup replication targets")
-	}
-
-	// For SYNCHRONOUS clusters, all regions must have the same target
-	if clusterType == "SYNCHRONOUS" {
-		uniqueTargets := make(map[string]bool)
-		for _, target := range regionGcpTargets {
-			uniqueTargets[target] = true
-		}
-		if len(uniqueTargets) > 1 {
-			return fmt.Errorf("all regions must have the same backup replication targets for synchronous clusters")
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This adds optional support for specifying how many availability zones a cluster uses in each region. The capability is hidden behind a feature flag so it can be rolled out gradually without affecting existing users.

When the flag is off, users who set this field get a clear error at plan time. When the flag is on, the value is sent to the API on create/update and read back into Terraform state.

## Changes

- Added `num_zones` to `cluster_region_info` on the cluster resource and data source
- Gated behind `YBM_FF_MULTI_ZONE_SUPPORT=true`
- Validation runs at plan time so misconfiguration is caught before apply
- Updated generated docs for the resource and data source

## Feature Flag
```bash
export YBM_FF_MULTI_ZONE_SUPPORT=true
```

## Example usage

```hcl
resource "ybm_cluster" "example" {
  # ... other cluster config ...

  cluster_region_info = [
    {
      region    = "us-west1"
      num_nodes = 3
      num_zones = 3
    }
  ]
}
```

#### Error when FF is disabled and `num_zones` is passed:
```bash
$ terraform plan
╷
│ Error: Invalid num_zones field
│ 
│   with ybm_cluster.backup_cluster,
│   on main.tf line 89, in resource "ybm_cluster" "backup_cluster":
│   89: resource "ybm_cluster" "backup_cluster" {
│ 
│ Multi-zone support feature disabled: The 'num_zones' field is set in cluster_region_info, but the MULTI_ZONE_SUPPORT feature flag is disabled. Set
│ YBM_FF_MULTI_ZONE_SUPPORT=true to enable it.
╵
```
