### PR TITLE
[CLOUDGA-34957] Fix cluster create/edit plan failures due to dynamic variables.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260715114419-049ca4dde3b6
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260716073402-ea61613f94b2
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260715114419-049ca4dde3b6 h1:7WQJKu/YgguTbE1+OCg4M34k1R0Bz8wM4sPxCmKFIOY=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260715114419-049ca4dde3b6/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260716073402-ea61613f94b2 h1:j9e6BDNcGjhVYHheDvrarmZHqkkTxq6sEzHzsxwLM1s=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260716073402-ea61613f94b2/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/resource_cluster.go
+++ b/managed/resource_cluster.go
@@ -1537,14 +1537,24 @@ func createCmkSpec(plan Cluster) (*openapiclient.CMKSpec, error) {
 }
 
 func (r resourceCluster) ValidateConfig(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
-	var clusterRegionInfo []RegionInfo
-	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("cluster_region_info"), &clusterRegionInfo)...)
+	// With dynamically typed vars (e.g. list(any)), cluster_region_info can be wholly
+	// unknown here; decoding into []RegionInfo then fails with "unhandled unknown value".
+	var clusterRegionInfoList types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("cluster_region_info"), &clusterRegionInfoList)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := validateMultiZoneSupport(clusterRegionInfo); err != nil {
-		resp.Diagnostics.AddError("Invalid num_zones field", err.Error())
+	if !clusterRegionInfoList.IsNull() && !clusterRegionInfoList.IsUnknown() {
+		var clusterRegionInfo []RegionInfo
+		resp.Diagnostics.Append(clusterRegionInfoList.ElementsAs(ctx, &clusterRegionInfo, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if err := validateMultiZoneSupport(clusterRegionInfo); err != nil {
+			resp.Diagnostics.AddError("Invalid num_zones field", err.Error())
+		}
 	}
 
 	var isMultiCloud types.Bool


### PR DESCRIPTION
### Issue
---
[CLOUDGA-34957](https://yugabyte.atlassian.net/browse/CLOUDGA-34957) : [Terraform] Cluster create/edit plan fails when dynamic variables are used for cluster_region_info

`ValidateConfig` (added for multi-zone support) decoded `cluster_region_info` into `[]RegionInfo`. With a dynamically typed variable such as `list(any)`, Terraform can mark that attribute as wholly unknown during `ValidateResourceConfig`. Framework cannot convert an unknown list into a Go slice, which produced `Value Conversion Error: unhandled unknown value`.

### Fix
---
The fix reads `cluster_region_info` as `types.List first` and runs `validateMultiZoneSupport` only when the value is known, so validation still runs for concrete config while unknown values no longer crash the provider.

* Before : 
```
# terraform plan -var 'cluster_region_info=[{"region": "asia-northeast3", "num_nodes": 3, "num_cores": 2, "memory_mb": 8192, "disk_size_gb": 100, "vpc_id": null}]'

Error running command plan: 1
Error: Value Conversion Error


  with ybm_cluster.single_region_cluster,
  on main.tf line 20, in resource "ybm_cluster" "single_region_cluster":
  20:   cluster_region_info = var.cluster_region_info


An unexpected error was encountered trying to build a value. This is always
an error in the provider. Please report the following to the provider
developer:


unhandled unknown value
```


* After : 

```
# terraform plan -var 'cluster_region_info=[{"region": "asia-northeast3", "num_nodes": 3, "num_cores": 2, "memory_mb": 8192, "disk_size_gb": 100, "vpc_id": null}]'

....
Plan: 1 to add, 0 to change, 0 to destroy.
```

[CLOUDGA-34957]: https://yugabyte.atlassian.net/browse/CLOUDGA-34957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ