### PR TITLE
Add AUTOSCALING feature flag and ybm_autoscaler_policy resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/sethvargo/go-retry v0.2.3
-	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260716073402-ea61613f94b2
+	github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260721090555-a18a4176484a
 )
 
 require github.com/stretchr/testify v1.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260716073402-ea61613f94b2 h1:j9e6BDNcGjhVYHheDvrarmZHqkkTxq6sEzHzsxwLM1s=
-github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260716073402-ea61613f94b2/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260721090555-a18a4176484a h1:rTopqXidCiKjHnlFHe1jcJXXcHA8txPo2x9NJb2OQl8=
+github.com/yugabyte/yugabytedb-managed-go-client-internal v0.0.0-20260721090555-a18a4176484a/go.mod h1:5vW0xIzIZw+1djkiWKx0qqNmqbRBSf4mjc4qw8lIMik=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/managed/fflags/feature_flags.go
+++ b/managed/fflags/feature_flags.go
@@ -17,6 +17,7 @@ const (
 	GCPBackupReplication FeatureFlag = "GCP_BACKUP_REPLICATION"
 	MultiZoneSupport     FeatureFlag = "MULTI_ZONE_SUPPORT"
 	MultiCloudSupport    FeatureFlag = "MULTI_CLOUD_SUPPORT"
+	Autoscaling          FeatureFlag = "AUTOSCALING"
 )
 
 var flagEnabled = map[FeatureFlag]bool{
@@ -24,6 +25,7 @@ var flagEnabled = map[FeatureFlag]bool{
 	GCPBackupReplication: false,
 	MultiZoneSupport:     false,
 	MultiCloudSupport:    false,
+	Autoscaling:          false,
 }
 
 func (f FeatureFlag) String() string {

--- a/managed/models.go
+++ b/managed/models.go
@@ -551,3 +551,44 @@ type PitrClone struct {
 	CloneAtMillis     types.Int64  `tfsdk:"clone_at_millis"`
 	State             types.String `tfsdk:"state"`
 }
+
+type AutoscalerPolicy struct {
+	AccountID types.String              `tfsdk:"account_id"`
+	ProjectID types.String              `tfsdk:"project_id"`
+	ClusterID types.String              `tfsdk:"cluster_id"`
+	PolicyID  types.String              `tfsdk:"policy_id"`
+	Status    types.String              `tfsdk:"status"`
+	Clusters  []AutoscalerPolicyCluster `tfsdk:"clusters"`
+}
+
+type AutoscalerPolicyCluster struct {
+	ClusterID types.String                    `tfsdk:"cluster_id"`
+	Type      types.String                    `tfsdk:"type"`
+	Regions   []AutoscalerPolicyClusterRegion `tfsdk:"regions"`
+}
+
+type AutoscalerPolicyClusterRegion struct {
+	Code     types.String                           `tfsdk:"code"`
+	Policies []AutoscalerClusterRegionScalingPolicy `tfsdk:"policies"`
+}
+
+type AutoscalerClusterRegionScalingPolicy struct {
+	ScalableResource types.String             `tfsdk:"scalable_resource"`
+	Min              types.Int64              `tfsdk:"min"`
+	Max              types.Int64              `tfsdk:"max"`
+	ScalingType      types.String             `tfsdk:"scaling_type"`
+	Clause           types.String             `tfsdk:"clause"`
+	Rules            []AutoscalerScalingRule  `tfsdk:"rules"`
+	ScalingAction    *AutoscalerScalingAction `tfsdk:"scaling_action"`
+}
+
+type AutoscalerScalingRule struct {
+	Resource         types.String  `tfsdk:"resource"`
+	Condition        types.String  `tfsdk:"condition"`
+	Value            types.Float64 `tfsdk:"value"`
+	EvaluationWindow types.String  `tfsdk:"evaluation_window"`
+}
+
+type AutoscalerScalingAction struct {
+	Delta types.Int64 `tfsdk:"delta"`
+}

--- a/managed/provider.go
+++ b/managed/provider.go
@@ -169,6 +169,11 @@ func (p *provider) GetResources(_ context.Context) (map[string]tfsdk.ResourceTyp
 		resources["ybm_dr_config"] = resourceDrConfigType{}
 	}
 
+	// Add autoscaler policy resource only if the feature flag is enabled
+	if fflags.IsFeatureFlagEnabled(fflags.Autoscaling) {
+		resources["ybm_autoscaler_policy"] = resourceAutoscalerPolicyType{}
+	}
+
 	return resources, nil
 }
 

--- a/managed/resource_autoscaler_policy.go
+++ b/managed/resource_autoscaler_policy.go
@@ -1,0 +1,468 @@
+/*
+ * Copyright © 2022-present Yugabyte, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package managed
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	openapiclient "github.com/yugabyte/yugabytedb-managed-go-client-internal"
+)
+
+type resourceAutoscalerPolicyType struct{}
+
+func (r resourceAutoscalerPolicyType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Description: `The resource to manage an autoscaler policy for a YugabyteDB Aeon cluster.
+Requires the AUTOSCALING feature flag (YBM_FF_AUTOSCALING=true).`,
+		Attributes: map[string]tfsdk.Attribute{
+			"account_id": {
+				Description: "The ID of the account this autoscaler policy belongs to.",
+				Type:        types.StringType,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.UseStateForUnknown(),
+				},
+			},
+			"project_id": {
+				Description: "The ID of the project this autoscaler policy belongs to.",
+				Type:        types.StringType,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.UseStateForUnknown(),
+				},
+			},
+			"cluster_id": {
+				Description: "The ID of the cluster this autoscaler policy belongs to.",
+				Type:        types.StringType,
+				Required:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.RequiresReplace(),
+				},
+			},
+			"policy_id": {
+				Description: "The ID of the autoscaler policy.",
+				Type:        types.StringType,
+				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.UseStateForUnknown(),
+				},
+			},
+			"status": {
+				Description: "The status of the autoscaler policy (ACTIVE or INACTIVE).",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			"clusters": {
+				Description: "Cluster-level autoscaler policy configuration (PRIMARY and/or READ_REPLICA).",
+				Required:    true,
+				Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+					"cluster_id": {
+						Description: "The ID of the cluster (PRIMARY or READ_REPLICA) this policy applies to.",
+						Type:        types.StringType,
+						Required:    true,
+					},
+					"type": {
+						Description: "Cluster type: PRIMARY or READ_REPLICA.",
+						Type:        types.StringType,
+						Required:    true,
+						Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("PRIMARY", "READ_REPLICA")},
+					},
+					"regions": {
+						Description: "Region-level autoscaler policy configuration.",
+						Required:    true,
+						Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+							"code": {
+								Description: "Cloud region code (for example, us-west1).",
+								Type:        types.StringType,
+								Required:    true,
+							},
+							"policies": {
+								Description: "Scaling policies for the region.",
+								Required:    true,
+								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+									"scalable_resource": {
+										Description: "Resource type that can be scaled (for example, NODE).",
+										Type:        types.StringType,
+										Required:    true,
+									},
+									"min": {
+										Description: "Minimum number of scalable resources.",
+										Type:        types.Int64Type,
+										Required:    true,
+									},
+									"max": {
+										Description: "Maximum number of scalable resources.",
+										Type:        types.Int64Type,
+										Required:    true,
+									},
+									"scaling_type": {
+										Description: "Direction of scaling: SCALE_IN or SCALE_OUT.",
+										Type:        types.StringType,
+										Required:    true,
+										Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("SCALE_IN", "SCALE_OUT")},
+									},
+									"clause": {
+										Description: "Logical operator for combining scaling rules: AND or OR.",
+										Type:        types.StringType,
+										Required:    true,
+										Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("AND", "OR")},
+									},
+									"rules": {
+										Description: "Rules that must be satisfied to trigger scaling.",
+										Required:    true,
+										Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+											"resource": {
+												Description: "Metric resource to evaluate: CPU or SQL_CONNECTION.",
+												Type:        types.StringType,
+												Required:    true,
+												Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("CPU", "SQL_CONNECTION")},
+											},
+											"condition": {
+												Description: "Comparison operator for the metric threshold: GT or LT.",
+												Type:        types.StringType,
+												Required:    true,
+												Validators:  []tfsdk.AttributeValidator{stringvalidator.OneOf("GT", "LT")},
+											},
+											"value": {
+												Description: "Threshold value for the metric.",
+												Type:        types.Float64Type,
+												Required:    true,
+											},
+											"evaluation_window": {
+												Description: "Duration over which the metric is evaluated (for example, 5m).",
+												Type:        types.StringType,
+												Required:    true,
+											},
+										}),
+									},
+									"scaling_action": {
+										Description: "Scaling action to apply when rules are satisfied.",
+										Required:    true,
+										Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+											"delta": {
+												Description: "Number of nodes to scale in or out.",
+												Type:        types.Int64Type,
+												Required:    true,
+											},
+										}),
+									},
+								}),
+							},
+						}),
+					},
+				}),
+			},
+		},
+	}, nil
+}
+
+func (r resourceAutoscalerPolicyType) NewResource(_ context.Context, p tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+	return resourceAutoscalerPolicy{
+		p: *(p.(*provider)),
+	}, nil
+}
+
+type resourceAutoscalerPolicy struct {
+	p provider
+}
+
+func getAutoscalerPolicyPlan(ctx context.Context, plan tfsdk.Plan, policy *AutoscalerPolicy) diag.Diagnostics {
+	var diags diag.Diagnostics
+	diags.Append(plan.GetAttribute(ctx, path.Root("cluster_id"), &policy.ClusterID)...)
+	diags.Append(plan.GetAttribute(ctx, path.Root("clusters"), &policy.Clusters)...)
+	return diags
+}
+
+func getAutoscalerPolicyState(ctx context.Context, state tfsdk.State, policy *AutoscalerPolicy) {
+	state.GetAttribute(ctx, path.Root("account_id"), &policy.AccountID)
+	state.GetAttribute(ctx, path.Root("project_id"), &policy.ProjectID)
+	state.GetAttribute(ctx, path.Root("cluster_id"), &policy.ClusterID)
+	state.GetAttribute(ctx, path.Root("policy_id"), &policy.PolicyID)
+	state.GetAttribute(ctx, path.Root("status"), &policy.Status)
+	state.GetAttribute(ctx, path.Root("clusters"), &policy.Clusters)
+}
+
+func buildCreateAutoscalerPolicyRequestSpec(clusters []AutoscalerPolicyCluster) openapiclient.CreateAutoscalerPolicyRequestSpec {
+	clusterSpecs := make([]openapiclient.AutoscalerClusterSpec, 0, len(clusters))
+	for _, cluster := range clusters {
+		regionSpecs := make([]openapiclient.AutoscalerClusterRegionSpec, 0, len(cluster.Regions))
+		for _, region := range cluster.Regions {
+			policySpecs := make([]openapiclient.AutoscalerClusterRegionPolicySpec, 0, len(region.Policies))
+			for _, policy := range region.Policies {
+				rules := make([]openapiclient.AutoscalerClusterRegionPolicyScalingRuleSpec, 0, len(policy.Rules))
+				for _, rule := range policy.Rules {
+					ruleSpec := openapiclient.NewAutoscalerClusterRegionPolicyScalingRuleSpec(
+						rule.Resource.Value,
+						rule.Condition.Value,
+						rule.Value.Value,
+						rule.EvaluationWindow.Value,
+					)
+					rules = append(rules, *ruleSpec)
+				}
+
+				action := openapiclient.NewAutoscalerClusterRegionPolicyScalingActionSpec(int32(policy.ScalingAction.Delta.Value))
+				policySpec := openapiclient.NewAutoscalerClusterRegionPolicySpec(
+					policy.ScalableResource.Value,
+					int32(policy.Min.Value),
+					int32(policy.Max.Value),
+					policy.ScalingType.Value,
+					policy.Clause.Value,
+					rules,
+					*action,
+				)
+				policySpecs = append(policySpecs, *policySpec)
+			}
+
+			regionSpec := openapiclient.NewAutoscalerClusterRegionSpec(region.Code.Value, policySpecs)
+			regionSpecs = append(regionSpecs, *regionSpec)
+		}
+
+		clusterSpec := openapiclient.NewAutoscalerClusterSpec(
+			cluster.ClusterID.Value,
+			cluster.Type.Value,
+			regionSpecs,
+		)
+		clusterSpecs = append(clusterSpecs, *clusterSpec)
+	}
+
+	return *openapiclient.NewCreateAutoscalerPolicyRequestSpec(clusterSpecs)
+}
+
+func mapAutoscalerPolicyFromResponse(
+	accountId string,
+	projectId string,
+	clusterId string,
+	response openapiclient.AutoscalerPolicyResponse,
+) AutoscalerPolicy {
+	data := response.GetData()
+	metadata := data.GetMetadata()
+	policy := AutoscalerPolicy{
+		AccountID: types.String{Value: accountId},
+		ProjectID: types.String{Value: projectId},
+		ClusterID: types.String{Value: clusterId},
+		PolicyID:  types.String{Value: metadata.GetId()},
+		Status:    types.String{Value: data.GetStatus()},
+		Clusters:  []AutoscalerPolicyCluster{},
+	}
+
+	for _, cluster := range data.GetClusters() {
+		tfCluster := AutoscalerPolicyCluster{
+			ClusterID: types.String{Value: cluster.GetClusterId()},
+			Type:      types.String{Value: cluster.GetType()},
+			Regions:   []AutoscalerPolicyClusterRegion{},
+		}
+
+		for _, region := range cluster.GetRegions() {
+			tfRegion := AutoscalerPolicyClusterRegion{
+				Code:     types.String{Value: region.GetCode()},
+				Policies: []AutoscalerClusterRegionScalingPolicy{},
+			}
+
+			for _, regionPolicy := range region.GetPolicies() {
+				tfRules := make([]AutoscalerScalingRule, 0, len(regionPolicy.GetRules()))
+				for _, rule := range regionPolicy.GetRules() {
+					tfRules = append(tfRules, AutoscalerScalingRule{
+						Resource:         types.String{Value: rule.GetResource()},
+						Condition:        types.String{Value: rule.GetCondition()},
+						Value:            types.Float64{Value: rule.GetValue()},
+						EvaluationWindow: types.String{Value: rule.GetEvaluationWindow()},
+					})
+				}
+
+				scalingAction := regionPolicy.GetScalingAction()
+				tfPolicy := AutoscalerClusterRegionScalingPolicy{
+					ScalableResource: types.String{Value: regionPolicy.GetScalableResource()},
+					Min:              types.Int64{Value: int64(regionPolicy.GetMin())},
+					Max:              types.Int64{Value: int64(regionPolicy.GetMax())},
+					ScalingType:      types.String{Value: regionPolicy.GetScalingType()},
+					Clause:           types.String{Value: regionPolicy.GetClause()},
+					Rules:            tfRules,
+					ScalingAction: &AutoscalerScalingAction{
+						Delta: types.Int64{Value: int64(scalingAction.GetDelta())},
+					},
+				}
+				tfRegion.Policies = append(tfRegion.Policies, tfPolicy)
+			}
+
+			tfCluster.Regions = append(tfCluster.Regions, tfRegion)
+		}
+
+		policy.Clusters = append(policy.Clusters, tfCluster)
+	}
+
+	return policy
+}
+
+func resourceAutoscalerPolicyRead(
+	accountId string,
+	projectId string,
+	clusterId string,
+	apiClient *openapiclient.APIClient,
+) (AutoscalerPolicy, bool, string) {
+	resp, response, err := apiClient.AutoscalerApi.ListAutoscalerPolicies(context.Background(), accountId, projectId, clusterId).Execute()
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return AutoscalerPolicy{}, false, "Delete resource"
+		}
+		return AutoscalerPolicy{}, false, getErrorMessage(response, err)
+	}
+
+	return mapAutoscalerPolicyFromResponse(accountId, projectId, clusterId, resp), true, ""
+}
+
+func (r resourceAutoscalerPolicy) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	if !r.p.configured {
+		resp.Diagnostics.AddError(
+			"Provider not configured",
+			"The provider wasn't configured before being applied, likely because it depends on an unknown value from another resource.",
+		)
+		return
+	}
+
+	var plan AutoscalerPolicy
+	resp.Diagnostics.Append(getAutoscalerPolicyPlan(ctx, req.Plan, &plan)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Debug(ctx, "Error while getting the plan for the autoscaler policy")
+		return
+	}
+
+	apiClient := r.p.client
+
+	accountId, getAccountOK, message := getAccountId(ctx, apiClient)
+	if !getAccountOK {
+		resp.Diagnostics.AddError("Unable to get account ID", message)
+		return
+	}
+
+	projectId, getProjectOK, message := getProjectId(ctx, apiClient, accountId)
+	if !getProjectOK {
+		resp.Diagnostics.AddError("Unable to get project ID", message)
+		return
+	}
+
+	clusterId := plan.ClusterID.Value
+	requestSpec := buildCreateAutoscalerPolicyRequestSpec(plan.Clusters)
+
+	_, response, err := apiClient.AutoscalerApi.CreateAutoscalerPolicy(ctx, accountId, projectId, clusterId).
+		CreateAutoscalerPolicyRequestSpec(requestSpec).
+		Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create autoscaler policy", getErrorMessage(response, err))
+		return
+	}
+
+	policy, readOK, message := resourceAutoscalerPolicyRead(accountId, projectId, clusterId, apiClient)
+	if !readOK {
+		resp.Diagnostics.AddError("Unable to read the state of the autoscaler policy after creation", message)
+		return
+	}
+
+	tflog.Debug(ctx, "Autoscaler policy created", map[string]interface{}{"policy": policy})
+
+	diags := resp.State.Set(ctx, &policy)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r resourceAutoscalerPolicy) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+	var state AutoscalerPolicy
+	getAutoscalerPolicyState(ctx, req.State, &state)
+
+	policy, readOK, message := resourceAutoscalerPolicyRead(
+		state.AccountID.Value,
+		state.ProjectID.Value,
+		state.ClusterID.Value,
+		r.p.client,
+	)
+	if !readOK {
+		if message == "Delete resource" {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unable to read the state of the autoscaler policy", message)
+		return
+	}
+
+	diags := resp.State.Set(ctx, &policy)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r resourceAutoscalerPolicy) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+	var plan AutoscalerPolicy
+	var state AutoscalerPolicy
+
+	getAutoscalerPolicyState(ctx, req.State, &state)
+	resp.Diagnostics.Append(getAutoscalerPolicyPlan(ctx, req.Plan, &plan)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Debug(ctx, "Error while getting the plan for the autoscaler policy update")
+		return
+	}
+
+	if plan.ClusterID.Value != state.ClusterID.Value {
+		resp.Diagnostics.AddError(
+			"Invalid edit to autoscaler policy",
+			"cluster_id cannot be changed. Destroy and recreate the resource to use a different cluster.",
+		)
+		return
+	}
+
+	accountId := state.AccountID.Value
+	projectId := state.ProjectID.Value
+	clusterId := state.ClusterID.Value
+	requestSpec := buildCreateAutoscalerPolicyRequestSpec(plan.Clusters)
+
+	_, response, err := r.p.client.AutoscalerApi.UpdateAutoscalerPolicy(ctx, accountId, projectId, clusterId).
+		CreateAutoscalerPolicyRequestSpec(requestSpec).
+		Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update autoscaler policy", getErrorMessage(response, err))
+		return
+	}
+
+	policy, readOK, message := resourceAutoscalerPolicyRead(accountId, projectId, clusterId, r.p.client)
+	if !readOK {
+		if message == "Delete resource" {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unable to read the state of the autoscaler policy after update", message)
+		return
+	}
+
+	diags := resp.State.Set(ctx, &policy)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r resourceAutoscalerPolicy) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	var state AutoscalerPolicy
+	getAutoscalerPolicyState(ctx, req.State, &state)
+
+	accountId := state.AccountID.Value
+	projectId := state.ProjectID.Value
+	clusterId := state.ClusterID.Value
+
+	response, err := r.p.client.AutoscalerApi.DeleteAutoscalerPolicy(ctx, accountId, projectId, clusterId).Execute()
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unable to delete autoscaler policy", getErrorMessage(response, err))
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r resourceAutoscalerPolicy) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	// Import identifier is the cluster ID.
+	tfsdk.ResourceImportStatePassthroughID(ctx, path.Root("cluster_id"), req, resp)
+}


### PR DESCRIPTION
## Summary
- Adds the `AUTOSCALING` provider feature flag (`YBM_FF_AUTOSCALING=true`)
- Introduces `ybm_autoscaler_policy` for create/read/update/delete of cluster autoscaler policies, registered only when the flag is enabled
- Bumps `yugabytedb-managed-go-client-internal` to pick up Autoscaler Update/Delete APIs

## Test plan
- [ ] `go build ./...` succeeds
- [ ] Without `YBM_FF_AUTOSCALING`, `ybm_autoscaler_policy` is not a registered resource
- [ ] With `YBM_FF_AUTOSCALING=true`, create/read/update/delete an autoscaler policy against a cluster with autoscaling enabled
- [ ] Import by `cluster_id` refreshes state correctly

Made with [Cursor](https://cursor.com)